### PR TITLE
Feature: Add configurable event types and hierarchy tracking (v0.5.0)

### DIFF
--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -2,7 +2,7 @@
 from .logger import ParquetLogger
 from typing import Optional, Dict, Any, List
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 
 def with_tags(*additional_tags: str, custom_id: Optional[str] = None,

--- a/langchain_callback_parquet_logger/logger.py
+++ b/langchain_callback_parquet_logger/logger.py
@@ -7,7 +7,7 @@ import atexit  # For automatic cleanup on exit
 import warnings
 from pathlib import Path
 from datetime import datetime, date, timezone
-from typing import Dict, Any, List, Optional, Literal
+from typing import Dict, Any, List, Optional, Literal, Set
 import pyarrow as pa
 import pyarrow.parquet as pq
 from langchain_core.callbacks import BaseCallbackHandler
@@ -16,6 +16,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 SCHEMA = pa.schema([
     ("timestamp", pa.timestamp("us", tz="UTC")),
     ("run_id", pa.string()),
+    ("parent_run_id", pa.string()),
     ("logger_custom_id", pa.string()),
     ("event_type", pa.string()),
     ("provider", pa.string()),
@@ -26,7 +27,13 @@ SCHEMA = pa.schema([
 class ParquetLogger(BaseCallbackHandler):
     """Simplified Parquet logger with flexible JSON payload schema."""
     
-    def __init__(self, log_dir: str = "./llm_logs", buffer_size: int = 100, provider: str = "openai", logger_metadata: Optional[Dict[str, Any]] = None, partition_on: Optional[Literal["date"]] = "date"):
+    def __init__(self, 
+                 log_dir: str = "./llm_logs", 
+                 buffer_size: int = 100, 
+                 provider: str = "openai", 
+                 logger_metadata: Optional[Dict[str, Any]] = None, 
+                 partition_on: Optional[Literal["date"]] = "date",
+                 event_types: Optional[List[str]] = None):
         """
         Initialize the Parquet logger.
         
@@ -36,6 +43,11 @@ class ParquetLogger(BaseCallbackHandler):
             provider: LLM provider name (default: "openai")
             logger_metadata: Optional dictionary of metadata to include with all log entries
             partition_on: Partitioning strategy - "date" for daily partitions or None for no partitioning (default: "date")
+            event_types: List of event types to log. If None, logs only LLM events.
+                Available types: 'llm_start', 'llm_end', 'llm_error',
+                                'chain_start', 'chain_end', 'chain_error',
+                                'tool_start', 'tool_end', 'tool_error',
+                                'agent_action', 'agent_finish'
         """
         self.log_dir = Path(log_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
@@ -43,6 +55,13 @@ class ParquetLogger(BaseCallbackHandler):
         self.provider = provider
         self.logger_metadata = logger_metadata or {}
         self.partition_on = partition_on
+        
+        # Set event types to log
+        if event_types is None:
+            # Default to LLM events only for backward compatibility
+            self.event_types: Set[str] = {'llm_start', 'llm_end', 'llm_error'}
+        else:
+            self.event_types: Set[str] = set(event_types)
         # Safely serialize metadata with fallback
         try:
             self.logger_metadata_json = json.dumps(self.logger_metadata, default=str)
@@ -106,6 +125,9 @@ class ParquetLogger(BaseCallbackHandler):
     
     def on_llm_start(self, serialized: Dict, prompts: List[str], **kwargs):
         """Log LLM start event with all request data in payload."""
+        if 'llm_start' not in self.event_types:
+            return
+            
         # Extract logger_custom_id from tags (persists through all events)
         logger_custom_id = self._extract_custom_id_from_tags(kwargs)
         
@@ -119,11 +141,13 @@ class ParquetLogger(BaseCallbackHandler):
             'tags': kwargs.get('tags', []),
             'metadata_dict': kwargs.get('metadata', {}),
             'tools': kwargs.get('tools', None),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
         }
         
         entry = {
             'timestamp': datetime.now(timezone.utc),
             'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
             'logger_custom_id': logger_custom_id,
             'event_type': 'llm_start',
             'provider': self.provider,
@@ -134,6 +158,9 @@ class ParquetLogger(BaseCallbackHandler):
     
     def on_llm_end(self, response, **kwargs):
         """Log LLM completion event with all response data in payload."""
+        if 'llm_end' not in self.event_types:
+            return
+            
         # Extract logger_custom_id from tags (persists through all events)
         logger_custom_id = self._extract_custom_id_from_tags(kwargs)
         
@@ -169,6 +196,7 @@ class ParquetLogger(BaseCallbackHandler):
         entry = {
             'timestamp': datetime.now(timezone.utc),
             'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
             'logger_custom_id': logger_custom_id,
             'event_type': 'llm_end',
             'provider': self.provider,
@@ -179,6 +207,9 @@ class ParquetLogger(BaseCallbackHandler):
     
     def on_llm_error(self, error, **kwargs):
         """Log LLM error event with error details in payload."""
+        if 'llm_error' not in self.event_types:
+            return
+            
         # Extract logger_custom_id from tags (persists through all events)
         logger_custom_id = self._extract_custom_id_from_tags(kwargs)
         
@@ -204,8 +235,253 @@ class ParquetLogger(BaseCallbackHandler):
         entry = {
             'timestamp': datetime.now(timezone.utc),
             'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
             'logger_custom_id': logger_custom_id,
             'event_type': 'llm_error',
+            'provider': self.provider,
+            'logger_metadata': self.logger_metadata_json,
+            'payload': self._safe_json_dumps(payload_data)
+        }
+        self._add_entry(entry)
+    
+    def on_chain_start(self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs):
+        """Log chain start event."""
+        if 'chain_start' not in self.event_types:
+            return
+            
+        logger_custom_id = self._extract_custom_id_from_tags(kwargs)
+        
+        payload_data = {
+            'name': serialized.get('name', 'unknown'),
+            'inputs': inputs,
+            'serialized': serialized,
+            'metadata': kwargs,
+            'tags': kwargs.get('tags', []),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
+        }
+        
+        entry = {
+            'timestamp': datetime.now(timezone.utc),
+            'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
+            'logger_custom_id': logger_custom_id,
+            'event_type': 'chain_start',
+            'provider': self.provider,
+            'logger_metadata': self.logger_metadata_json,
+            'payload': self._safe_json_dumps(payload_data)
+        }
+        self._add_entry(entry)
+    
+    def on_chain_end(self, outputs: Dict[str, Any], **kwargs):
+        """Log chain end event."""
+        if 'chain_end' not in self.event_types:
+            return
+            
+        logger_custom_id = self._extract_custom_id_from_tags(kwargs)
+        
+        payload_data = {
+            'outputs': outputs,
+            'metadata': kwargs,
+            'tags': kwargs.get('tags', []),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
+        }
+        
+        entry = {
+            'timestamp': datetime.now(timezone.utc),
+            'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
+            'logger_custom_id': logger_custom_id,
+            'event_type': 'chain_end',
+            'provider': self.provider,
+            'logger_metadata': self.logger_metadata_json,
+            'payload': self._safe_json_dumps(payload_data)
+        }
+        self._add_entry(entry)
+    
+    def on_chain_error(self, error: Exception, **kwargs):
+        """Log chain error event."""
+        if 'chain_error' not in self.event_types:
+            return
+            
+        logger_custom_id = self._extract_custom_id_from_tags(kwargs)
+        
+        payload_data = {
+            'error': str(error),
+            'error_type': type(error).__name__,
+            'metadata': kwargs,
+            'tags': kwargs.get('tags', []),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
+        }
+        
+        # Add error details if available
+        if hasattr(error, '__dict__'):
+            payload_data['error_details'] = {k: str(v) for k, v in error.__dict__.items() 
+                                            if not k.startswith('_')}
+        
+        entry = {
+            'timestamp': datetime.now(timezone.utc),
+            'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
+            'logger_custom_id': logger_custom_id,
+            'event_type': 'chain_error',
+            'provider': self.provider,
+            'logger_metadata': self.logger_metadata_json,
+            'payload': self._safe_json_dumps(payload_data)
+        }
+        self._add_entry(entry)
+    
+    def on_tool_start(self, serialized: Dict[str, Any], input_str: str, **kwargs):
+        """Log tool start event."""
+        if 'tool_start' not in self.event_types:
+            return
+            
+        logger_custom_id = self._extract_custom_id_from_tags(kwargs)
+        
+        payload_data = {
+            'name': serialized.get('name', 'unknown'),
+            'description': serialized.get('description', ''),
+            'input': input_str,
+            'serialized': serialized,
+            'metadata': kwargs,
+            'tags': kwargs.get('tags', []),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
+        }
+        
+        entry = {
+            'timestamp': datetime.now(timezone.utc),
+            'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
+            'logger_custom_id': logger_custom_id,
+            'event_type': 'tool_start',
+            'provider': self.provider,
+            'logger_metadata': self.logger_metadata_json,
+            'payload': self._safe_json_dumps(payload_data)
+        }
+        self._add_entry(entry)
+    
+    def on_tool_end(self, output: str, **kwargs):
+        """Log tool end event."""
+        if 'tool_end' not in self.event_types:
+            return
+            
+        logger_custom_id = self._extract_custom_id_from_tags(kwargs)
+        
+        payload_data = {
+            'output': output,
+            'metadata': kwargs,
+            'tags': kwargs.get('tags', []),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
+        }
+        
+        entry = {
+            'timestamp': datetime.now(timezone.utc),
+            'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
+            'logger_custom_id': logger_custom_id,
+            'event_type': 'tool_end',
+            'provider': self.provider,
+            'logger_metadata': self.logger_metadata_json,
+            'payload': self._safe_json_dumps(payload_data)
+        }
+        self._add_entry(entry)
+    
+    def on_tool_error(self, error: Exception, **kwargs):
+        """Log tool error event."""
+        if 'tool_error' not in self.event_types:
+            return
+            
+        logger_custom_id = self._extract_custom_id_from_tags(kwargs)
+        
+        payload_data = {
+            'error': str(error),
+            'error_type': type(error).__name__,
+            'metadata': kwargs,
+            'tags': kwargs.get('tags', []),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
+        }
+        
+        # Add error details if available
+        if hasattr(error, '__dict__'):
+            payload_data['error_details'] = {k: str(v) for k, v in error.__dict__.items() 
+                                            if not k.startswith('_')}
+        
+        entry = {
+            'timestamp': datetime.now(timezone.utc),
+            'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
+            'logger_custom_id': logger_custom_id,
+            'event_type': 'tool_error',
+            'provider': self.provider,
+            'logger_metadata': self.logger_metadata_json,
+            'payload': self._safe_json_dumps(payload_data)
+        }
+        self._add_entry(entry)
+    
+    def on_agent_action(self, action, **kwargs):
+        """Log agent action event."""
+        if 'agent_action' not in self.event_types:
+            return
+            
+        logger_custom_id = self._extract_custom_id_from_tags(kwargs)
+        
+        # Handle AgentAction object
+        if hasattr(action, '__dict__'):
+            action_data = {
+                'tool': getattr(action, 'tool', ''),
+                'tool_input': getattr(action, 'tool_input', ''),
+                'log': getattr(action, 'log', ''),
+            }
+        else:
+            action_data = str(action)
+        
+        payload_data = {
+            'action': action_data,
+            'metadata': kwargs,
+            'tags': kwargs.get('tags', []),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
+        }
+        
+        entry = {
+            'timestamp': datetime.now(timezone.utc),
+            'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
+            'logger_custom_id': logger_custom_id,
+            'event_type': 'agent_action',
+            'provider': self.provider,
+            'logger_metadata': self.logger_metadata_json,
+            'payload': self._safe_json_dumps(payload_data)
+        }
+        self._add_entry(entry)
+    
+    def on_agent_finish(self, finish, **kwargs):
+        """Log agent finish event."""
+        if 'agent_finish' not in self.event_types:
+            return
+            
+        logger_custom_id = self._extract_custom_id_from_tags(kwargs)
+        
+        # Handle AgentFinish object
+        if hasattr(finish, '__dict__'):
+            finish_data = {
+                'return_values': getattr(finish, 'return_values', {}),
+                'log': getattr(finish, 'log', ''),
+            }
+        else:
+            finish_data = str(finish)
+        
+        payload_data = {
+            'finish': finish_data,
+            'metadata': kwargs,
+            'tags': kwargs.get('tags', []),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else None,
+        }
+        
+        entry = {
+            'timestamp': datetime.now(timezone.utc),
+            'run_id': str(kwargs.get('run_id', '')),
+            'parent_run_id': str(kwargs.get('parent_run_id', '')) if kwargs.get('parent_run_id') else '',
+            'logger_custom_id': logger_custom_id,
+            'event_type': 'agent_finish',
             'provider': self.provider,
             'logger_metadata': self.logger_metadata_json,
             'payload': self._safe_json_dumps(payload_data)
@@ -234,6 +510,7 @@ class ParquetLogger(BaseCallbackHandler):
             ts = pa.array([e["timestamp"] for e in self.buffer],
                           type=pa.timestamp("us", tz="UTC"))
             run_id = pa.array([e["run_id"] for e in self.buffer], type=pa.string())
+            parent_run_id = pa.array([e["parent_run_id"] for e in self.buffer], type=pa.string())
             logger_custom_id = pa.array([e["logger_custom_id"] for e in self.buffer], type=pa.string())
             event_type = pa.array([e["event_type"] for e in self.buffer], type=pa.string())
             provider = pa.array([e["provider"] for e in self.buffer], type=pa.string())
@@ -242,7 +519,7 @@ class ParquetLogger(BaseCallbackHandler):
             
             # Create table with explicit schema
             table = pa.Table.from_arrays(
-                [ts, run_id, logger_custom_id, event_type, provider, logger_metadata, payload],
+                [ts, run_id, parent_run_id, logger_custom_id, event_type, provider, logger_metadata, payload],
                 schema=SCHEMA
             )
             

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "0.4.1"
+version = "0.5.0"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_enhanced_logging.py
+++ b/tests/test_enhanced_logging.py
@@ -1,0 +1,325 @@
+"""
+Tests for enhanced event logging features (chains, tools, agents, hierarchy).
+"""
+
+import pytest
+import json
+from pathlib import Path
+from datetime import date
+from uuid import UUID
+import pandas as pd
+from unittest.mock import Mock
+
+from langchain_callback_parquet_logger import ParquetLogger
+
+
+class TestEnhancedEventLogging:
+    """Test enhanced event logging features."""
+    
+    def test_configurable_event_types(self, temp_log_dir):
+        """Test that event types can be configured."""
+        # Create logger with only chain events enabled
+        logger = ParquetLogger(
+            temp_log_dir,
+            buffer_size=1,
+            event_types=['chain_start', 'chain_end']
+        )
+        
+        # Should log chain events
+        logger.on_chain_start(
+            {'name': 'test_chain'},
+            {'input': 'test'},
+            run_id='chain-123',
+            parent_run_id='parent-456'
+        )
+        
+        # Should NOT log LLM events
+        logger.on_llm_start(
+            {'kwargs': {'model_name': 'gpt-4'}},
+            ['test prompt'],
+            run_id='llm-789'
+        )
+        
+        # Check that only chain event was logged
+        files = list(Path(temp_log_dir).glob("**/*.parquet"))
+        assert len(files) == 1
+        
+        df = pd.read_parquet(files[0])
+        assert len(df) == 1
+        assert df.iloc[0]['event_type'] == 'chain_start'
+    
+    def test_chain_events(self, temp_log_dir):
+        """Test logging of chain events."""
+        logger = ParquetLogger(
+            temp_log_dir,
+            buffer_size=10,
+            event_types=['chain_start', 'chain_end', 'chain_error']
+        )
+        
+        # Test chain start
+        logger.on_chain_start(
+            {'name': 'test_chain', 'type': 'sequential'},
+            {'question': 'What is 2+2?'},
+            run_id='chain-start-123',
+            parent_run_id='parent-123',
+            tags=['test-tag']
+        )
+        
+        # Test chain end
+        logger.on_chain_end(
+            {'answer': '4', 'confidence': 0.99},
+            run_id='chain-end-123',
+            parent_run_id='parent-123'
+        )
+        
+        # Test chain error
+        test_error = ValueError("Chain processing failed")
+        logger.on_chain_error(
+            test_error,
+            run_id='chain-error-123',
+            parent_run_id='parent-123'
+        )
+        
+        logger.flush()
+        
+        # Verify events were logged correctly
+        files = list(Path(temp_log_dir).glob("**/*.parquet"))
+        df = pd.read_parquet(files[0])
+        assert len(df) == 3
+        
+        # Check chain_start
+        start_event = df[df['event_type'] == 'chain_start'].iloc[0]
+        assert start_event['run_id'] == 'chain-start-123'
+        assert start_event['parent_run_id'] == 'parent-123'
+        payload = json.loads(start_event['payload'])
+        assert payload['name'] == 'test_chain'
+        assert payload['inputs']['question'] == 'What is 2+2?'
+        
+        # Check chain_end
+        end_event = df[df['event_type'] == 'chain_end'].iloc[0]
+        assert end_event['run_id'] == 'chain-end-123'
+        payload = json.loads(end_event['payload'])
+        assert payload['outputs']['answer'] == '4'
+        
+        # Check chain_error
+        error_event = df[df['event_type'] == 'chain_error'].iloc[0]
+        assert error_event['run_id'] == 'chain-error-123'
+        payload = json.loads(error_event['payload'])
+        assert 'Chain processing failed' in payload['error']
+    
+    def test_tool_events(self, temp_log_dir):
+        """Test logging of tool events."""
+        logger = ParquetLogger(
+            temp_log_dir,
+            buffer_size=10,
+            event_types=['tool_start', 'tool_end', 'tool_error']
+        )
+        
+        # Test tool start
+        logger.on_tool_start(
+            {'name': 'calculator', 'description': 'Performs math operations'},
+            '2 + 2',
+            run_id='tool-start-123',
+            parent_run_id='llm-123'
+        )
+        
+        # Test tool end
+        logger.on_tool_end(
+            '4',
+            run_id='tool-end-123',
+            parent_run_id='llm-123'
+        )
+        
+        # Test tool error
+        test_error = RuntimeError("Calculator malfunction")
+        logger.on_tool_error(
+            test_error,
+            run_id='tool-error-123',
+            parent_run_id='llm-123'
+        )
+        
+        logger.flush()
+        
+        # Verify events
+        files = list(Path(temp_log_dir).glob("**/*.parquet"))
+        df = pd.read_parquet(files[0])
+        assert len(df) == 3
+        
+        # Check tool_start
+        start_event = df[df['event_type'] == 'tool_start'].iloc[0]
+        payload = json.loads(start_event['payload'])
+        assert payload['name'] == 'calculator'
+        assert payload['input'] == '2 + 2'
+        
+        # Check tool_end
+        end_event = df[df['event_type'] == 'tool_end'].iloc[0]
+        payload = json.loads(end_event['payload'])
+        assert payload['output'] == '4'
+        
+        # Check tool_error
+        error_event = df[df['event_type'] == 'tool_error'].iloc[0]
+        payload = json.loads(error_event['payload'])
+        assert 'Calculator malfunction' in payload['error']
+    
+    def test_agent_events(self, temp_log_dir):
+        """Test logging of agent events."""
+        logger = ParquetLogger(
+            temp_log_dir,
+            buffer_size=10,
+            event_types=['agent_action', 'agent_finish']
+        )
+        
+        # Test agent action with mock AgentAction
+        action = Mock()
+        action.tool = 'search'
+        action.tool_input = 'weather today'
+        action.log = 'Searching for weather information'
+        
+        logger.on_agent_action(
+            action,
+            run_id='agent-action-123',
+            parent_run_id='agent-123'
+        )
+        
+        # Test agent finish with mock AgentFinish
+        finish = Mock()
+        finish.return_values = {'answer': 'Sunny, 72°F'}
+        finish.log = 'Found weather information'
+        
+        logger.on_agent_finish(
+            finish,
+            run_id='agent-finish-123',
+            parent_run_id='agent-123'
+        )
+        
+        logger.flush()
+        
+        # Verify events
+        files = list(Path(temp_log_dir).glob("**/*.parquet"))
+        df = pd.read_parquet(files[0])
+        assert len(df) == 2
+        
+        # Check agent_action
+        action_event = df[df['event_type'] == 'agent_action'].iloc[0]
+        payload = json.loads(action_event['payload'])
+        assert payload['action']['tool'] == 'search'
+        assert payload['action']['tool_input'] == 'weather today'
+        
+        # Check agent_finish
+        finish_event = df[df['event_type'] == 'agent_finish'].iloc[0]
+        payload = json.loads(finish_event['payload'])
+        assert payload['finish']['return_values']['answer'] == 'Sunny, 72°F'
+    
+    def test_parent_run_id_hierarchy(self, temp_log_dir):
+        """Test that parent_run_id properly tracks hierarchy."""
+        logger = ParquetLogger(
+            temp_log_dir,
+            buffer_size=10,
+            event_types=[
+                'chain_start', 'llm_start', 'tool_start',
+                'tool_end', 'llm_end', 'chain_end'
+            ]
+        )
+        
+        # Simulate hierarchical execution: Chain -> LLM -> Tool
+        logger.on_chain_start(
+            {'name': 'main_chain'},
+            {'question': 'Calculate 5 * 7'},
+            run_id='chain-1',
+            parent_run_id=None  # Top-level
+        )
+        
+        logger.on_llm_start(
+            {'kwargs': {'model_name': 'gpt-4'}},
+            ['I need to calculate 5 * 7'],
+            run_id='llm-1',
+            parent_run_id='chain-1'  # Child of chain
+        )
+        
+        logger.on_tool_start(
+            {'name': 'calculator'},
+            '5 * 7',
+            run_id='tool-1',
+            parent_run_id='llm-1'  # Child of LLM
+        )
+        
+        logger.on_tool_end(
+            '35',
+            run_id='tool-1',
+            parent_run_id='llm-1'
+        )
+        
+        logger.on_llm_end(
+            Mock(llm_output={'token_usage': {'total': 20}}),
+            run_id='llm-1',
+            parent_run_id='chain-1'
+        )
+        
+        logger.on_chain_end(
+            {'result': '35'},
+            run_id='chain-1',
+            parent_run_id=None
+        )
+        
+        logger.flush()
+        
+        # Verify hierarchy
+        files = list(Path(temp_log_dir).glob("**/*.parquet"))
+        df = pd.read_parquet(files[0])
+        assert len(df) == 6
+        
+        # Check hierarchy relationships
+        chain_events = df[df['run_id'] == 'chain-1']
+        assert all(chain_events['parent_run_id'] == '')
+        
+        llm_events = df[df['run_id'] == 'llm-1']
+        assert all(llm_events['parent_run_id'] == 'chain-1')
+        
+        tool_events = df[df['run_id'] == 'tool-1']
+        assert all(tool_events['parent_run_id'] == 'llm-1')
+    
+    def test_backward_compatibility(self, temp_log_dir):
+        """Test that default behavior maintains backward compatibility."""
+        # Logger without event_types should default to LLM events only
+        logger = ParquetLogger(temp_log_dir, buffer_size=10)
+        
+        # Should log LLM events
+        logger.on_llm_start(
+            {'kwargs': {'model_name': 'gpt-4'}},
+            ['test'],
+            run_id='llm-1'
+        )
+        
+        # Should NOT log chain events (not in default)
+        logger.on_chain_start(
+            {'name': 'chain'},
+            {'input': 'test'},
+            run_id='chain-1'
+        )
+        
+        logger.flush()
+        
+        # Only LLM event should be logged
+        files = list(Path(temp_log_dir).glob("**/*.parquet"))
+        df = pd.read_parquet(files[0])
+        assert len(df) == 1
+        assert df.iloc[0]['event_type'] == 'llm_start'
+    
+    def test_parent_run_id_column_always_present(self, temp_log_dir):
+        """Test that parent_run_id column is always present even when empty."""
+        logger = ParquetLogger(temp_log_dir, buffer_size=1)
+        
+        # Log event without parent_run_id
+        logger.on_llm_start(
+            {'kwargs': {'model_name': 'gpt-4'}},
+            ['test'],
+            run_id='llm-1'
+            # No parent_run_id provided
+        )
+        
+        # Check column exists and is empty string
+        files = list(Path(temp_log_dir).glob("**/*.parquet"))
+        df = pd.read_parquet(files[0])
+        
+        assert 'parent_run_id' in df.columns
+        assert df.iloc[0]['parent_run_id'] == ''


### PR DESCRIPTION
Enhanced ParquetLogger with comprehensive event support:
- Added configurable event_types parameter for selective logging
- Implemented callbacks for chains, tools, and agents
- Added parent_run_id as top-level column for hierarchy tracking
- Maintained backward compatibility (defaults to LLM events only)

New callback methods:
- Chain events: on_chain_start, on_chain_end, on_chain_error
- Tool events: on_tool_start, on_tool_end, on_tool_error
- Agent events: on_agent_action, on_agent_finish

Schema changes:
- Added parent_run_id column (8 columns total)
- Enables tracking of execution hierarchy (chains → LLMs → tools)

Testing:
- Added comprehensive test suite for all new event types
- Tests for hierarchy tracking with parent_run_id
- Tests for backward compatibility

This enables full observability of LangChain execution flows.