### PR TITLE
Feat/retriever additions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
     
     - name: Check package installation
       run: |
-        python -c "from langchain_callback_parquet_logger import ParquetLogger, with_tags, batch_run; print('Import successful')"
+        python -c "from langchain_callback_parquet_logger import ParquetLogger, with_tags, Batch; print('Import successful')"

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -12,7 +12,7 @@ from .config import (
     EventType,
     RetrievalConfig,
 )
-from .batch import batch_run, batch_process, retrieve_batch_responses
+from .batch import Batch, BatchOutcome
 
 # Optional imports with better error messages
 try:
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.2.1"
+__version__ = "3.3.0"
 
 __all__ = [
     # Core
@@ -30,9 +30,8 @@ __all__ = [
     'with_tags',
 
     # Batch processing
-    'batch_run',
-    'batch_process',
-    'retrieve_batch_responses',
+    'Batch',
+    'BatchOutcome',
 
     # Configurations
     'S3Config',

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.3.0a4"
+__version__ = "3.3.0a5"
 
 __all__ = [
     # Core

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.3.0a6"
+__version__ = "3.3.0a7"
 
 __all__ = [
     # Core

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.3.0"
+__version__ = "3.3.0a1"
 
 __all__ = [
     # Core

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.3.0a2"
+__version__ = "3.3.0a3"
 
 __all__ = [
     # Core

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.3.0a1"
+__version__ = "3.3.0a2"
 
 __all__ = [
     # Core

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.3.0a3"
+__version__ = "3.3.0a4"
 
 __all__ = [
     # Core

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.3.0a7"
+__version__ = "4.0.0"
 
 __all__ = [
     # Core

--- a/langchain_callback_parquet_logger/__init__.py
+++ b/langchain_callback_parquet_logger/__init__.py
@@ -22,7 +22,7 @@ except ImportError:
     retrieve_background_responses = None
 
 
-__version__ = "3.3.0a5"
+__version__ = "3.3.0a6"
 
 __all__ = [
     # Core

--- a/langchain_callback_parquet_logger/background_retrieval.py
+++ b/langchain_callback_parquet_logger/background_retrieval.py
@@ -6,7 +6,6 @@ with automatic logging to Parquet files, rate limiting, and checkpoint support.
 """
 
 import asyncio
-import json
 import random
 import time
 from datetime import datetime, timezone
@@ -25,7 +24,7 @@ except ImportError:
     openai = None
 
 from .logger import ParquetLogger
-from .config import StorageConfig, JobConfig, RetrievalConfig
+from .config import StorageConfig, JobConfig, RetrievalConfig, ColumnConfig
 from .storage import create_storage, LocalStorage, S3Storage
 
 # OpenAI response statuses that mean "done, stop polling"
@@ -110,16 +109,7 @@ async def retrieve_background_responses(
     storage_config: Optional[StorageConfig] = None,
     job_config: Optional[JobConfig] = None,
     retrieval_config: Optional[RetrievalConfig] = None,
-    response_id_col: str = "response_id",
-    custom_id_col: str = "custom_id",
-    batch_size: int = 50,
-    max_retries: int = 3,
-    timeout: float = 30.0,
-    poll_interval: float = 30.0,
-    max_poll_attempts: int = 40,
-    show_progress: bool = True,
-    checkpoint_file: Optional[str] = None,
-    return_results: bool = True,
+    column_config: Optional[ColumnConfig] = None,
 ) -> Optional["pd.DataFrame"]:
     """
     Retrieve background responses from OpenAI and log them to Parquet.
@@ -140,7 +130,8 @@ async def retrieve_background_responses(
         and retries only those.
 
     **Explicit mode** (pass a ``df`` directly):
-        Provide a DataFrame with ``response_id`` and ``custom_id`` columns, as before.
+        Provide a DataFrame with ``response_id`` and ``custom_id`` columns (or
+        the column names configured in ``column_config``).
 
     Args:
         df: Optional DataFrame containing response IDs to retrieve.  If omitted,
@@ -152,23 +143,17 @@ async def retrieve_background_responses(
         storage_config: StorageConfig used to locate existing log files for
             auto-discovery and to write new log entries.
         job_config: Optional JobConfig used to resolve the full storage path (same
-            object passed to ``batch_process()``).
-        retrieval_config: Optional RetrievalConfig controlling polling behavior and
-            the auto-discovery source (``source="local"`` or ``source="s3"``).
+            object passed to ``Batch``).
+        retrieval_config: Optional RetrievalConfig controlling all polling behavior
+            (poll_interval, max_poll_attempts, batch_size, timeout, max_retries,
+            show_progress, checkpoint_file, return_results, source).
             Defaults to ``RetrievalConfig()`` (local, conservative polling settings).
-        response_id_col: Column name containing response IDs (default: "response_id")
-        custom_id_col: Column name containing custom IDs (default: "custom_id")
-        batch_size: Number of concurrent requests (default: 50)
-        max_retries: Maximum retries per API call for transient errors (default: 3)
-        timeout: Timeout per individual API request in seconds (default: 30.0)
-        poll_interval: Seconds to wait between status checks (default: 30.0)
-        max_poll_attempts: Maximum polls per response before giving up (default: 40)
-        show_progress: Show progress bar (default: True)
-        checkpoint_file: Optional path to checkpoint file for resume capability
-        return_results: If False, don't keep results in memory (default: True)
+        column_config: Optional ColumnConfig specifying which DataFrame columns hold
+            the response_id and custom_id values.  Defaults to ``ColumnConfig()``
+            (columns named "response_id" and "custom_id").
 
     Returns:
-        DataFrame with retrieval results if return_results=True, else None.
+        DataFrame with retrieval results if rc.return_results=True, else None.
         Result columns: response_id, status, openai_response, error
 
     Example — auto-discovery::
@@ -203,8 +188,9 @@ async def retrieve_background_responses(
     # Suppress Pydantic serialization warnings globally
     warnings.filterwarnings("ignore", category=UserWarning, module=r"^pydantic")
 
-    # Resolve retrieval configuration (source, polling params, etc.)
+    # Resolve configuration objects
     rc = retrieval_config or RetrievalConfig()
+    cc = column_config or ColumnConfig()
 
     # --- Auto-discovery mode ---
     if df is None:
@@ -214,7 +200,7 @@ async def retrieve_background_responses(
                 "Pass a DataFrame with response IDs, or a StorageConfig to "
                 "auto-discover pending responses from existing log files."
             )
-        # Resolve storage path (reuse same logic as batch_process)
+        # Resolve storage path (reuse same logic as Batch)
         from .batch import _build_storage_paths
         local_path, resolved_s3_config = _build_storage_paths(
             job_config or JobConfig(), storage_config
@@ -233,10 +219,12 @@ async def retrieve_background_responses(
         df = _query_pending_responses(read_storage)
 
         if df.empty:
-            print("No pending responses found in storage.")
-            return pd.DataFrame() if return_results else None
+            if rc.show_progress:
+                print("No pending responses found in storage.")
+            return pd.DataFrame() if rc.return_results else None
 
-        print(f"Auto-discovered {len(df)} pending response(s) from storage.")
+        if rc.show_progress:
+            print(f"Auto-discovered {len(df)} pending response(s) from storage.")
 
         # Auto-create logger pointing at the same full path if not supplied
         # (always write to all configured backends, regardless of read source)
@@ -244,59 +232,50 @@ async def retrieve_background_responses(
             logger = ParquetLogger(log_dir=str(local_path), s3_config=resolved_s3_config)
 
     # --- Validate required columns ---
-    if response_id_col not in df.columns:
-        raise ValueError(f"Column '{response_id_col}' not found in DataFrame")
-    if custom_id_col not in df.columns:
-        warnings.warn(f"Column '{custom_id_col}' not found. Using empty string for custom IDs.")
+    if cc.response_id not in df.columns:
+        raise ValueError(f"Column '{cc.response_id}' not found in DataFrame")
+    if cc.custom_id not in df.columns:
+        warnings.warn(f"Column '{cc.custom_id}' not found. Using empty string for custom IDs.")
         df = df.copy()
-        df[custom_id_col] = ""
+        df[cc.custom_id] = ""
 
-    # Initialize progress tracking
-    progress_bar = None
-    if show_progress:
-        try:
-            from tqdm.auto import tqdm
-            progress_bar = tqdm(total=len(df), desc="Retrieving responses", position=0, leave=True)
-        except Exception:
-            print(f"Retrieving {len(df)} responses...")
+    # Initialize manual progress tracking
+    total_count = len(df)
+    progress_interval = 1 if total_count <= 20 else max(1, total_count // 10)
 
     # Load checkpoint if exists
     processed_ids = set()
     failed_ids = {}
-    if checkpoint_file and Path(checkpoint_file).exists():
+    if rc.checkpoint_file and Path(rc.checkpoint_file).exists():
         try:
-            checkpoint_df = pd.read_parquet(checkpoint_file)
+            checkpoint_df = pd.read_parquet(rc.checkpoint_file)
             processed_ids = set(checkpoint_df['response_id'].values)
             if 'error' in checkpoint_df.columns:
                 failed_ids = dict(zip(
                     checkpoint_df[checkpoint_df['error'].notna()]['response_id'],
                     checkpoint_df[checkpoint_df['error'].notna()]['error']
                 ))
-            if progress_bar:
-                progress_bar.update(len(processed_ids))
-            print(f"Resumed from checkpoint: {len(processed_ids)} already processed")
+            if rc.show_progress:
+                print(f"Resumed from checkpoint: {len(processed_ids)} already processed")
         except Exception as e:
             warnings.warn(f"Failed to load checkpoint: {e}")
 
     # Prepare results storage
-    results = [] if return_results else None
+    results = [] if rc.return_results else None
     checkpoint_batch = []
 
     # Rate limiting state (shared across concurrent tasks via nonlocal)
     rate_limit_reset = 0
-    rate_limit_remaining = batch_size
+    rate_limit_remaining = rc.batch_size
 
     async def retrieve_single(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Retrieve a single response: poll until terminal status, with error retries."""
-        response_id = row[response_id_col]
-        custom_id = row.get(custom_id_col, "")
+        response_id = row[cc.response_id]
+        custom_id = row.get(cc.custom_id, "")
 
         # Skip if already processed
         if response_id in processed_ids:
-            if progress_bar:
-                progress_bar.update(1)
-                progress_bar.refresh()
-            if return_results:
+            if rc.return_results:
                 return {
                     'response_id': response_id,
                     'status': 'already_processed',
@@ -308,15 +287,13 @@ async def retrieve_background_responses(
         def _log(event_type: str, data: dict):
             """Log a background retrieval event using the standard SCHEMA format.
 
-            Entries match the structure produced by ParquetLogger._log_event():
-            - run_id is set to response_id for top-level queryability
-            - payload contains execution wrapper + data + raw sections
+            Delegates to logger._log_event() so all entries go through the same
+            code path as regular ParquetLogger events, including _safe_json_dumps().
             """
             if logger:
-                ts = datetime.now(timezone.utc)
                 payload = {
                     "event_type": event_type,
-                    "timestamp": ts.isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                     "execution": {
                         "run_id": response_id,
                         "parent_run_id": "",
@@ -327,15 +304,7 @@ async def retrieve_background_responses(
                     "data": data,
                     "raw": {}
                 }
-                logger._add_entry({
-                    'timestamp': ts,
-                    'run_id': response_id,
-                    'parent_run_id': '',
-                    'custom_id': custom_id,
-                    'event_type': event_type,
-                    'logger_metadata': logger.logger_metadata_json,
-                    'payload': json.dumps(payload),
-                })
+                logger._log_event(payload)
 
         _log('background_retrieval_attempt', {
             'response_id': response_id,
@@ -343,7 +312,7 @@ async def retrieve_background_responses(
         })
 
         # Outer polling loop — keeps going while response is pending
-        for poll_attempt in range(max_poll_attempts):
+        for poll_attempt in range(rc.max_poll_attempts):
             nonlocal rate_limit_reset, rate_limit_remaining
 
             # Check rate limits before making a request
@@ -354,11 +323,11 @@ async def retrieve_background_responses(
             # Inner error-retry loop — retries only on transient failures
             response = None
             last_error = None
-            for error_attempt in range(max_retries):
+            for error_attempt in range(rc.max_retries):
                 try:
                     response = await asyncio.wait_for(
                         openai_client.responses.retrieve(response_id),
-                        timeout=timeout,
+                        timeout=rc.timeout,
                     )
                     # Update rate limit state from response headers
                     if hasattr(response, 'headers'):
@@ -371,7 +340,7 @@ async def retrieve_background_responses(
                     break  # successful API call
 
                 except asyncio.TimeoutError:
-                    last_error = f"Timeout after {timeout}s"
+                    last_error = f"Timeout after {rc.timeout}s"
                     await asyncio.sleep(2 ** error_attempt)
 
                 except Exception as e:
@@ -390,14 +359,11 @@ async def retrieve_background_responses(
                     'response_id': response_id,
                     'error': last_error,
                     'error_type': 'retrieval_failed',
-                    'attempts': max_retries,
+                    'attempts': rc.max_retries,
                 })
                 failed_ids[response_id] = last_error
                 processed_ids.add(response_id)
-                if progress_bar:
-                    progress_bar.update(1)
-                    progress_bar.refresh()
-                if return_results:
+                if rc.return_results:
                     return {'response_id': response_id, 'status': 'failed', 'openai_response': None, 'error': last_error}
                 return None
 
@@ -428,10 +394,7 @@ async def retrieve_background_responses(
                     'poll_attempts': poll_attempt + 1,
                 })
                 processed_ids.add(response_id)
-                if progress_bar:
-                    progress_bar.update(1)
-                    progress_bar.refresh()
-                if return_results:
+                if rc.return_results:
                     return {'response_id': response_id, 'status': 'completed', 'openai_response': response_data, 'error': None}
                 return None
 
@@ -447,10 +410,7 @@ async def retrieve_background_responses(
                 })
                 failed_ids[response_id] = error_msg
                 processed_ids.add(response_id)
-                if progress_bar:
-                    progress_bar.update(1)
-                    progress_bar.refresh()
-                if return_results:
+                if rc.return_results:
                     return {'response_id': response_id, 'status': response_status, 'openai_response': response_data, 'error': error_msg}
                 return None
 
@@ -460,32 +420,30 @@ async def retrieve_background_responses(
                     'response_id': response_id,
                     'openai_status': response_status,
                     'poll_attempt': poll_attempt + 1,
-                    'next_check_in': poll_interval,
+                    'next_check_in': rc.poll_interval,
                 })
-                await asyncio.sleep(poll_interval)
+                await asyncio.sleep(rc.poll_interval)
 
         # Exhausted max_poll_attempts without a terminal status
-        error_msg = f"Exceeded max_poll_attempts ({max_poll_attempts}) — response never completed"
+        error_msg = f"Exceeded max_poll_attempts ({rc.max_poll_attempts}) — response never completed"
         _log('background_retrieval_error', {
             'response_id': response_id,
             'error': error_msg,
             'error_type': 'poll_timeout',
-            'poll_attempts': max_poll_attempts,
+            'poll_attempts': rc.max_poll_attempts,
         })
         failed_ids[response_id] = error_msg
         processed_ids.add(response_id)
-        if progress_bar:
-            progress_bar.update(1)
-            progress_bar.refresh()
-        if return_results:
+        if rc.return_results:
             return {'response_id': response_id, 'status': 'poll_timeout', 'openai_response': None, 'error': error_msg}
         return None
 
     # Process in batches (controls max concurrency)
     rows = df.to_dict('records')
+    completed_count = len(processed_ids)  # account for checkpoint-resumed items
 
-    for i in range(0, len(rows), batch_size):
-        batch = rows[i:i + batch_size]
+    for i in range(0, len(rows), rc.batch_size):
+        batch = rows[i:i + rc.batch_size]
 
         batch_results = await asyncio.gather(
             *[retrieve_single(row) for row in batch],
@@ -494,51 +452,50 @@ async def retrieve_background_responses(
 
         for row, result in zip(batch, batch_results):
             if isinstance(result, Exception):
-                response_id = row[response_id_col]
+                response_id = row[cc.response_id]
                 error_msg = str(result)
                 failed_ids[response_id] = error_msg
                 processed_ids.add(response_id)
-                if progress_bar:
-                    progress_bar.update(1)
-                    progress_bar.refresh()
-                if return_results:
+                if rc.return_results:
                     results.append({
                         'response_id': response_id,
                         'status': 'error',
                         'openai_response': None,
                         'error': error_msg,
                     })
-            elif result is not None and return_results:
+            elif result is not None and rc.return_results:
                 results.append(result)
 
             # Add to checkpoint batch
-            if checkpoint_file:
+            if rc.checkpoint_file:
                 checkpoint_batch.append({
-                    'response_id': row[response_id_col],
+                    'response_id': row[cc.response_id],
                     'processed': True,
-                    'error': failed_ids.get(row[response_id_col]),
+                    'error': failed_ids.get(row[cc.response_id]),
                 })
 
+        # Print progress after each gather batch completes
+        completed_count += len(batch)
+        if rc.show_progress and (completed_count % progress_interval == 0 or completed_count == total_count):
+            print(f"  Retrieved {completed_count}/{total_count} responses ({100 * completed_count // total_count}%)")
+
         # Save checkpoint periodically
-        if checkpoint_file and len(checkpoint_batch) >= 100:
-            save_checkpoint(checkpoint_file, checkpoint_batch)
+        if rc.checkpoint_file and len(checkpoint_batch) >= 100:
+            save_checkpoint(rc.checkpoint_file, checkpoint_batch)
             checkpoint_batch = []
 
     # Final checkpoint save
-    if checkpoint_file and checkpoint_batch:
-        save_checkpoint(checkpoint_file, checkpoint_batch)
+    if rc.checkpoint_file and checkpoint_batch:
+        save_checkpoint(rc.checkpoint_file, checkpoint_batch)
 
     # Final flush of logger buffer
     if logger and hasattr(logger, 'flush'):
         logger.flush()
 
-    # Clean up
-    if progress_bar:
-        progress_bar.close()
+    if rc.show_progress:
+        print(f"\nRetrieval complete: {len(processed_ids)} processed, {len(failed_ids)} failed")
 
-    print(f"\nRetrieval complete: {len(processed_ids)} processed, {len(failed_ids)} failed")
-
-    if return_results:
+    if rc.return_results:
         return pd.DataFrame(results)
     return None
 

--- a/langchain_callback_parquet_logger/background_retrieval.py
+++ b/langchain_callback_parquet_logger/background_retrieval.py
@@ -25,17 +25,91 @@ except ImportError:
     openai = None
 
 from .logger import ParquetLogger
+from .config import StorageConfig, JobConfig, RetrievalConfig
+from .storage import create_storage, LocalStorage, S3Storage
 
 # OpenAI response statuses that mean "done, stop polling"
 _TERMINAL_STATUSES = {"completed", "failed", "cancelled", "expired"}
 # Statuses that indicate the response is still being processed
 _PENDING_STATUSES = {"in_progress", "queued", "processing"}
 
+# Background retrieval event types (all share the same run_id = response_id)
+_BACKGROUND_EVENT_TYPES = {
+    'background_retrieval_attempt',
+    'background_retrieval_pending',
+    'background_retrieval_complete',
+    'background_retrieval_error',
+}
+# Terminal event types — a response with one of these as its latest event is done
+_TERMINAL_RETRIEVAL_EVENT_TYPES = {
+    'background_retrieval_complete',
+    'background_retrieval_error',
+}
+
+
+def _query_pending_responses(storage) -> "pd.DataFrame":
+    """Read parquet files from storage and find responses with non-terminal status.
+
+    Uses ``run_id`` (= response_id) and ``event_type`` to determine which responses
+    are still pending.  A response is pending when its latest logged event_type is
+    NOT one of the terminal types (``background_retrieval_complete`` /
+    ``background_retrieval_error``).
+
+    Returns:
+        DataFrame with columns: response_id, custom_id
+    """
+    if pd is None:
+        raise ImportError(
+            "pandas is required for auto-discovery. Install with: pip install pandas"
+        )
+
+    try:
+        files = storage.list_files()
+    except Exception as e:
+        warnings.warn(f"Failed to list files from storage: {e}")
+        return pd.DataFrame(columns=['response_id', 'custom_id'])
+
+    if not files:
+        return pd.DataFrame(columns=['response_id', 'custom_id'])
+
+    frames = []
+    for f in files:
+        try:
+            table = storage.read_table(Path(f))
+            df = table.to_pandas()
+            bg_df = df[df['event_type'].isin(_BACKGROUND_EVENT_TYPES)]
+            if not bg_df.empty:
+                frames.append(bg_df[['run_id', 'custom_id', 'event_type', 'timestamp']])
+        except Exception:
+            continue
+
+    if not frames:
+        return pd.DataFrame(columns=['response_id', 'custom_id'])
+
+    all_df = pd.concat(frames, ignore_index=True)
+
+    # For each run_id (= response_id), find the latest event by timestamp
+    latest = all_df.sort_values('timestamp').groupby('run_id').last().reset_index()
+
+    # Keep only non-terminal entries (responses still pending)
+    pending = latest[~latest['event_type'].isin(_TERMINAL_RETRIEVAL_EVENT_TYPES)]
+
+    if pending.empty:
+        return pd.DataFrame(columns=['response_id', 'custom_id'])
+
+    return pd.DataFrame({
+        'response_id': pending['run_id'].values,
+        'custom_id': pending['custom_id'].values,
+    })
+
 
 async def retrieve_background_responses(
-    df: "pd.DataFrame",
+    df: Optional["pd.DataFrame"] = None,
     openai_client=None,
     logger: Optional[ParquetLogger] = None,
+    storage_config: Optional[StorageConfig] = None,
+    job_config: Optional[JobConfig] = None,
+    retrieval_config: Optional[RetrievalConfig] = None,
     response_id_col: str = "response_id",
     custom_id_col: str = "custom_id",
     batch_size: int = 50,
@@ -55,20 +129,40 @@ async def retrieve_background_responses(
     ``background_retrieval_pending`` event and the final outcome as either
     ``background_retrieval_complete`` or ``background_retrieval_error``.
 
+    All log entries follow the standard SCHEMA (same as ParquetLogger) with
+    ``run_id`` set to the OpenAI ``response_id`` for easy top-level querying.
+
+    **Auto-discovery mode** (default when no ``df`` is supplied):
+        Pass ``storage_config`` (and optionally ``job_config``) to point the retriever
+        at the same storage location used by ``batch_process()``.  The retriever reads
+        existing parquet files, finds every response whose latest logged event is
+        non-terminal (``background_retrieval_attempt`` or ``background_retrieval_pending``),
+        and retries only those.
+
+    **Explicit mode** (pass a ``df`` directly):
+        Provide a DataFrame with ``response_id`` and ``custom_id`` columns, as before.
+
     Args:
-        df: DataFrame containing response IDs to retrieve
-        openai_client: Initialized OpenAI async client
-        logger: Optional ParquetLogger instance for logging responses
+        df: Optional DataFrame containing response IDs to retrieve.  If omitted,
+            ``storage_config`` must be provided and responses are auto-discovered
+            from existing log files.
+        openai_client: Initialized OpenAI async client (created automatically if None)
+        logger: Optional ParquetLogger instance for logging.  Auto-created from
+            ``storage_config`` when ``df`` is None and no logger is supplied.
+        storage_config: StorageConfig used to locate existing log files for
+            auto-discovery and to write new log entries.
+        job_config: Optional JobConfig used to resolve the full storage path (same
+            object passed to ``batch_process()``).
+        retrieval_config: Optional RetrievalConfig controlling polling behavior and
+            the auto-discovery source (``source="local"`` or ``source="s3"``).
+            Defaults to ``RetrievalConfig()`` (local, conservative polling settings).
         response_id_col: Column name containing response IDs (default: "response_id")
         custom_id_col: Column name containing custom IDs (default: "custom_id")
         batch_size: Number of concurrent requests (default: 50)
-        max_retries: Maximum retries per API call for transient errors such as
-            rate limits, timeouts, and 5xx server errors (default: 3)
+        max_retries: Maximum retries per API call for transient errors (default: 3)
         timeout: Timeout per individual API request in seconds (default: 30.0)
-        poll_interval: Seconds to wait between status checks when a response is
-            still pending (default: 30.0)
-        max_poll_attempts: Maximum number of times to poll a single response before
-            giving up. Total max wait ≈ poll_interval × max_poll_attempts (default: 40)
+        poll_interval: Seconds to wait between status checks (default: 30.0)
+        max_poll_attempts: Maximum polls per response before giving up (default: 40)
         show_progress: Show progress bar (default: True)
         checkpoint_file: Optional path to checkpoint file for resume capability
         return_results: If False, don't keep results in memory (default: True)
@@ -77,31 +171,79 @@ async def retrieve_background_responses(
         DataFrame with retrieval results if return_results=True, else None.
         Result columns: response_id, status, openai_response, error
 
-    Example:
-        >>> import openai
-        >>> from langchain_callback_parquet_logger import ParquetLogger, retrieve_background_responses
-        >>>
-        >>> client = openai.AsyncClient()
+    Example — auto-discovery::
+
+        >>> results = await retrieve_background_responses(
+        ...     storage_config=StorageConfig(output_dir="./my_logs"),
+        ...     job_config=JobConfig(category="research"),
+        ...     openai_client=client,
+        ... )
+
+    Example — explicit DataFrame::
+
         >>> df = pd.DataFrame({
         ...     'response_id': ['resp_123', 'resp_456'],
         ...     'custom_id': ['user-001', 'user-002']
         ... })
-        >>>
         >>> with ParquetLogger('./logs') as logger:
         ...     results = await retrieve_background_responses(df, client, logger=logger)
     """
     if pd is None:
-        raise ImportError("pandas is required for background retrieval. Install with: pip install pandas")
+        raise ImportError(
+            "pandas is required for background retrieval. Install with: pip install pandas"
+        )
 
     if openai_client is None:
         if openai is None:
-            raise ImportError("openai is required for background retrieval. Install with: pip install openai")
+            raise ImportError(
+                "openai is required for background retrieval. Install with: pip install openai"
+            )
         openai_client = openai.AsyncOpenAI()
 
     # Suppress Pydantic serialization warnings globally
     warnings.filterwarnings("ignore", category=UserWarning, module=r"^pydantic")
 
-    # Validate required columns
+    # Resolve retrieval configuration (source, polling params, etc.)
+    rc = retrieval_config or RetrievalConfig()
+
+    # --- Auto-discovery mode ---
+    if df is None:
+        if storage_config is None:
+            raise ValueError(
+                "Either 'df' or 'storage_config' must be provided. "
+                "Pass a DataFrame with response IDs, or a StorageConfig to "
+                "auto-discover pending responses from existing log files."
+            )
+        # Resolve storage path (reuse same logic as batch_process)
+        from .batch import _build_storage_paths
+        local_path, resolved_s3_config = _build_storage_paths(
+            job_config or JobConfig(), storage_config
+        )
+
+        # Select a single backend based on retrieval_config.source
+        if rc.source == "s3":
+            if resolved_s3_config is None:
+                raise ValueError(
+                    "retrieval_config.source='s3' requires storage_config.s3_config to be set."
+                )
+            read_storage = S3Storage(resolved_s3_config)
+        else:  # "local" (default)
+            read_storage = LocalStorage(local_path)
+
+        df = _query_pending_responses(read_storage)
+
+        if df.empty:
+            print("No pending responses found in storage.")
+            return pd.DataFrame() if return_results else None
+
+        print(f"Auto-discovered {len(df)} pending response(s) from storage.")
+
+        # Auto-create logger pointing at the same full path if not supplied
+        # (always write to all configured backends, regardless of read source)
+        if logger is None:
+            logger = ParquetLogger(log_dir=str(local_path), s3_config=resolved_s3_config)
+
+    # --- Validate required columns ---
     if response_id_col not in df.columns:
         raise ValueError(f"Column '{response_id_col}' not found in DataFrame")
     if custom_id_col not in df.columns:
@@ -163,11 +305,31 @@ async def retrieve_background_responses(
                 }
             return None
 
-        def _log(event_type: str, payload: dict):
+        def _log(event_type: str, data: dict):
+            """Log a background retrieval event using the standard SCHEMA format.
+
+            Entries match the structure produced by ParquetLogger._log_event():
+            - run_id is set to response_id for top-level queryability
+            - payload contains execution wrapper + data + raw sections
+            """
             if logger:
+                ts = datetime.now(timezone.utc)
+                payload = {
+                    "event_type": event_type,
+                    "timestamp": ts.isoformat(),
+                    "execution": {
+                        "run_id": response_id,
+                        "parent_run_id": "",
+                        "custom_id": custom_id,
+                        "tags": [],
+                        "metadata": {}
+                    },
+                    "data": data,
+                    "raw": {}
+                }
                 logger._add_entry({
-                    'timestamp': datetime.now(timezone.utc),
-                    'run_id': '',
+                    'timestamp': ts,
+                    'run_id': response_id,
                     'parent_run_id': '',
                     'custom_id': custom_id,
                     'event_type': event_type,

--- a/langchain_callback_parquet_logger/background_retrieval.py
+++ b/langchain_callback_parquet_logger/background_retrieval.py
@@ -110,6 +110,7 @@ async def retrieve_background_responses(
     job_config: Optional[JobConfig] = None,
     retrieval_config: Optional[RetrievalConfig] = None,
     column_config: Optional[ColumnConfig] = None,
+    response_parser=None,
 ) -> Optional["pd.DataFrame"]:
     """
     Retrieve background responses from OpenAI and log them to Parquet.
@@ -367,6 +368,13 @@ async def retrieve_background_responses(
                     return {'response_id': response_id, 'status': 'failed', 'openai_response': None, 'error': last_error}
                 return None
 
+            # Extract output_text BEFORE model_dump — it's a computed property on the
+            # OpenAI Response object that is not serialized by model_dump().
+            # Storing it at the top level lets _parse_from_openai_response() find it
+            # without navigating the nested output[].content[] array (which can have
+            # null content items for reasoning outputs).
+            output_text = getattr(response, 'output_text', None)
+
             # Serialize the response object
             if hasattr(response, 'model_dump'):
                 response_data = response.model_dump(mode='json', by_alias=False)
@@ -377,6 +385,10 @@ async def retrieve_background_responses(
             else:
                 response_data = {'response': str(response)}
 
+            # Store output_text at top level for easy access
+            if output_text:
+                response_data['output_text'] = output_text
+
             # Check the response status — prefer the serialized dict, fall back to
             # the attribute, then default to 'completed' for backward compatibility
             # (guards against mock objects or responses with no status field).
@@ -386,16 +398,25 @@ async def retrieve_background_responses(
             response_status = _s if isinstance(_s, str) and _s else 'completed'
 
             if response_status == 'completed':
+                # Apply structured output parser if provided (dict for Parquet serialization)
+                parsed_output = None
+                if response_parser is not None:
+                    try:
+                        parsed_output = response_parser(response_data)
+                    except Exception:
+                        pass
+
                 _log('background_retrieval_complete', {
                     'response_id': response_id,
                     'openai_response': response_data,
+                    'parsed_output': parsed_output,
                     'status': 'completed',
                     'retrieval_time': datetime.now(timezone.utc).isoformat(),
                     'poll_attempts': poll_attempt + 1,
                 })
                 processed_ids.add(response_id)
                 if rc.return_results:
-                    return {'response_id': response_id, 'status': 'completed', 'openai_response': response_data, 'error': None}
+                    return {'response_id': response_id, 'status': 'completed', 'openai_response': response_data, 'parsed_output': parsed_output, 'error': None}
                 return None
 
             elif response_status in _TERMINAL_STATUSES:

--- a/langchain_callback_parquet_logger/background_retrieval.py
+++ b/langchain_callback_parquet_logger/background_retrieval.py
@@ -10,7 +10,7 @@ import random
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 import warnings
 
 try:
@@ -24,7 +24,7 @@ except ImportError:
     openai = None
 
 from .logger import ParquetLogger
-from .config import StorageConfig, JobConfig, RetrievalConfig, ColumnConfig
+from .config import StorageConfig, JobConfig, RetrievalConfig, ColumnConfig, S3Config
 from .storage import create_storage, LocalStorage, S3Storage
 
 # OpenAI response statuses that mean "done, stop polling"
@@ -32,8 +32,9 @@ _TERMINAL_STATUSES = {"completed", "failed", "cancelled", "expired"}
 # Statuses that indicate the response is still being processed
 _PENDING_STATUSES = {"in_progress", "queued", "processing"}
 
-# Background retrieval event types (all share the same run_id = response_id)
+# Background retrieval event types (run_id = LangChain UUID; response_id stored in data.response_id)
 _BACKGROUND_EVENT_TYPES = {
+    'background_retrieval_queued',     # logged by Batch.run() when a background response is detected
     'background_retrieval_attempt',
     'background_retrieval_pending',
     'background_retrieval_complete',
@@ -53,14 +54,16 @@ def _query_pending_responses(storage) -> "pd.DataFrame":
     A response is pending when its latest logged event_type is NOT one of the
     terminal types (``background_retrieval_complete`` / ``background_retrieval_error``).
 
-    ``response_id`` is read from ``payload.data.response_id`` when present (current
-    schema where ``run_id`` is the LangChain UUID), falling back to the ``run_id``
-    column for backward compatibility with older log files written before this change.
+    ``response_id`` is read from ``payload.data.response_id`` (current schema where
+    ``run_id`` is the LangChain UUID). Events without ``data.response_id`` in the
+    payload are excluded.
 
     Returns:
-        DataFrame with columns: response_id, custom_id
+        DataFrame with columns: response_id, custom_id, run_id, parent_run_id, tags
     """
     import json as _json
+
+    _EMPTY = ['response_id', 'custom_id', 'run_id', 'parent_run_id', 'tags']
 
     if pd is None:
         raise ImportError(
@@ -71,10 +74,10 @@ def _query_pending_responses(storage) -> "pd.DataFrame":
         files = storage.list_files()
     except Exception as e:
         warnings.warn(f"Failed to list files from storage: {e}")
-        return pd.DataFrame(columns=['response_id', 'custom_id'])
+        return pd.DataFrame(columns=_EMPTY)
 
     if not files:
-        return pd.DataFrame(columns=['response_id', 'custom_id'])
+        return pd.DataFrame(columns=_EMPTY)
 
     frames = []
     for f in files:
@@ -83,26 +86,37 @@ def _query_pending_responses(storage) -> "pd.DataFrame":
             df = table.to_pandas()
             bg_df = df[df['event_type'].isin(_BACKGROUND_EVENT_TYPES)]
             if not bg_df.empty:
-                frames.append(bg_df[['run_id', 'custom_id', 'event_type', 'timestamp', 'payload']])
+                frames.append(bg_df[['run_id', 'parent_run_id', 'custom_id', 'event_type', 'timestamp', 'payload']])
         except Exception:
             continue
 
     if not frames:
-        return pd.DataFrame(columns=['response_id', 'custom_id'])
+        return pd.DataFrame(columns=_EMPTY)
 
     all_df = pd.concat(frames, ignore_index=True)
 
-    # Extract the OpenAI response_id from payload.data.response_id.
-    # Current schema: run_id = LangChain UUID, data.response_id = OpenAI resp_xxx.
-    # Fallback: run_id = OpenAI resp_xxx (older log files written before this change).
-    def _extract_resp_id(row):
+    # Extract OpenAI response_id and tags from payload JSON.
+    # run_id = LangChain UUID (top-level column); data.response_id = OpenAI resp_xxx.
+    # Events without data.response_id are excluded (empty string → filtered below).
+    def _extract_resp_id_and_tags(row) -> "pd.Series":
         try:
-            resp_id = _json.loads(row['payload']).get('data', {}).get('response_id')
-            return resp_id or row['run_id']
+            parsed = _json.loads(row['payload'])
+            resp_id = parsed.get('data', {}).get('response_id') or ''
+            tags = parsed.get('execution', {}).get('tags', []) or []
         except Exception:
-            return row['run_id']
+            resp_id = ''
+            tags = []
+        return pd.Series({'effective_response_id': resp_id, 'extracted_tags': tags})
 
-    all_df['effective_response_id'] = all_df.apply(_extract_resp_id, axis=1)
+    extracted = all_df.apply(_extract_resp_id_and_tags, axis=1)
+    all_df['effective_response_id'] = extracted['effective_response_id']
+    all_df['extracted_tags'] = extracted['extracted_tags']
+
+    # Drop rows with no response_id (not background retrieval events we care about)
+    all_df = all_df[all_df['effective_response_id'] != '']
+
+    if all_df.empty:
+        return pd.DataFrame(columns=_EMPTY)
 
     # For each response, find the latest event by timestamp
     latest = all_df.sort_values('timestamp').groupby('effective_response_id').last().reset_index()
@@ -111,12 +125,36 @@ def _query_pending_responses(storage) -> "pd.DataFrame":
     pending = latest[~latest['event_type'].isin(_TERMINAL_RETRIEVAL_EVENT_TYPES)]
 
     if pending.empty:
-        return pd.DataFrame(columns=['response_id', 'custom_id'])
+        return pd.DataFrame(columns=_EMPTY)
 
     return pd.DataFrame({
         'response_id': pending['effective_response_id'].values,
         'custom_id': pending['custom_id'].values,
+        'run_id': pending['run_id'].values,
+        'parent_run_id': pending['parent_run_id'].values,
+        'tags': pending['extracted_tags'].values,
     })
+
+
+def _parse_s3_uri(uri: str) -> Tuple[str, str]:
+    """Parse an S3 URI into (bucket, prefix).
+
+    Examples::
+
+        >>> _parse_s3_uri("s3://my-bucket/path/to/logs/")
+        ('my-bucket', 'path/to/logs/')
+        >>> _parse_s3_uri("s3://my-bucket")
+        ('my-bucket', '')
+    """
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI (must start with 's3://'): {uri!r}")
+    rest = uri[5:]
+    parts = rest.split("/", 1)
+    bucket = parts[0]
+    if not bucket:
+        raise ValueError(f"S3 URI has no bucket: {uri!r}")
+    prefix = parts[1] if len(parts) > 1 else ""
+    return bucket, prefix
 
 
 async def retrieve_background_responses(
@@ -128,6 +166,7 @@ async def retrieve_background_responses(
     retrieval_config: Optional[RetrievalConfig] = None,
     column_config: Optional[ColumnConfig] = None,
     response_parser=None,
+    s3_path: Optional[str] = None,
 ) -> Optional["pd.DataFrame"]:
     """
     Retrieve background responses from OpenAI and log them to Parquet.
@@ -137,15 +176,17 @@ async def retrieve_background_responses(
     ``background_retrieval_pending`` event and the final outcome as either
     ``background_retrieval_complete`` or ``background_retrieval_error``.
 
-    All log entries follow the standard SCHEMA (same as ParquetLogger) with
-    ``run_id`` set to the OpenAI ``response_id`` for easy top-level querying.
+    **S3 resume mode** (simplest for cross-process resume):
+        Pass ``s3_path="s3://bucket/prefix/"`` to auto-discover pending responses
+        from S3 and write new retrieval events back to the same S3 location.
+        No ``storage_config`` or ``job_config`` needed.
 
     **Auto-discovery mode** (default when no ``df`` is supplied):
         Pass ``storage_config`` (and optionally ``job_config``) to point the retriever
         at the same storage location used by ``batch_process()``.  The retriever reads
         existing parquet files, finds every response whose latest logged event is
-        non-terminal (``background_retrieval_attempt`` or ``background_retrieval_pending``),
-        and retries only those.
+        non-terminal (``background_retrieval_attempt``, ``background_retrieval_pending``,
+        or ``background_retrieval_queued``), and retries only those.
 
     **Explicit mode** (pass a ``df`` directly):
         Provide a DataFrame with ``response_id`` and ``custom_id`` columns (or
@@ -153,11 +194,11 @@ async def retrieve_background_responses(
 
     Args:
         df: Optional DataFrame containing response IDs to retrieve.  If omitted,
-            ``storage_config`` must be provided and responses are auto-discovered
-            from existing log files.
+            ``storage_config`` or ``s3_path`` must be provided and responses are
+            auto-discovered from existing log files.
         openai_client: Initialized OpenAI async client (created automatically if None)
         logger: Optional ParquetLogger instance for logging.  Auto-created from
-            ``storage_config`` when ``df`` is None and no logger is supplied.
+            ``storage_config`` or ``s3_path`` when no logger is supplied.
         storage_config: StorageConfig used to locate existing log files for
             auto-discovery and to write new log entries.
         job_config: Optional JobConfig used to resolve the full storage path (same
@@ -169,10 +210,21 @@ async def retrieve_background_responses(
         column_config: Optional ColumnConfig specifying which DataFrame columns hold
             the response_id and custom_id values.  Defaults to ``ColumnConfig()``
             (columns named "response_id" and "custom_id").
+        s3_path: Optional S3 URI (e.g. ``"s3://my-bucket/path/to/logs/"``).  When
+            provided, pending responses are auto-discovered from that S3 location and
+            new retrieval events are written back there.  Takes precedence over
+            ``storage_config``-based discovery when ``df`` is None.
 
     Returns:
         DataFrame with retrieval results if rc.return_results=True, else None.
         Result columns: response_id, status, openai_response, error
+
+    Example — S3 resume (cross-process)::
+
+        >>> results = await retrieve_background_responses(
+        ...     s3_path="s3://my-bucket/jobs/research/",
+        ...     openai_client=client,
+        ... )
 
     Example — auto-discovery::
 
@@ -209,6 +261,26 @@ async def retrieve_background_responses(
     # Resolve configuration objects
     rc = retrieval_config or RetrievalConfig()
     cc = column_config or ColumnConfig()
+
+    # --- S3 path shortcut (pre-process before standard auto-discovery) ---
+    if s3_path is not None:
+        import tempfile
+        bucket, prefix = _parse_s3_uri(s3_path)
+        s3_cfg = S3Config(bucket=bucket, prefix=prefix)
+        if df is None:
+            read_storage = S3Storage(s3_cfg)
+            df = _query_pending_responses(read_storage)
+            if df.empty:
+                if rc.show_progress:
+                    print("No pending responses found in S3.")
+                return pd.DataFrame() if rc.return_results else None
+            if rc.show_progress:
+                print(f"Auto-discovered {len(df)} pending response(s) from S3.")
+        if logger is None:
+            logger = ParquetLogger(
+                log_dir=tempfile.mkdtemp(prefix="bgretrieval_"),
+                s3_config=s3_cfg,
+            )
 
     # --- Auto-discovery mode ---
     if df is None:

--- a/langchain_callback_parquet_logger/background_retrieval.py
+++ b/langchain_callback_parquet_logger/background_retrieval.py
@@ -49,14 +49,19 @@ _TERMINAL_RETRIEVAL_EVENT_TYPES = {
 def _query_pending_responses(storage) -> "pd.DataFrame":
     """Read parquet files from storage and find responses with non-terminal status.
 
-    Uses ``run_id`` (= response_id) and ``event_type`` to determine which responses
-    are still pending.  A response is pending when its latest logged event_type is
-    NOT one of the terminal types (``background_retrieval_complete`` /
-    ``background_retrieval_error``).
+    Uses ``event_type`` to determine which responses are still pending.
+    A response is pending when its latest logged event_type is NOT one of the
+    terminal types (``background_retrieval_complete`` / ``background_retrieval_error``).
+
+    ``response_id`` is read from ``payload.data.response_id`` when present (current
+    schema where ``run_id`` is the LangChain UUID), falling back to the ``run_id``
+    column for backward compatibility with older log files written before this change.
 
     Returns:
         DataFrame with columns: response_id, custom_id
     """
+    import json as _json
+
     if pd is None:
         raise ImportError(
             "pandas is required for auto-discovery. Install with: pip install pandas"
@@ -78,7 +83,7 @@ def _query_pending_responses(storage) -> "pd.DataFrame":
             df = table.to_pandas()
             bg_df = df[df['event_type'].isin(_BACKGROUND_EVENT_TYPES)]
             if not bg_df.empty:
-                frames.append(bg_df[['run_id', 'custom_id', 'event_type', 'timestamp']])
+                frames.append(bg_df[['run_id', 'custom_id', 'event_type', 'timestamp', 'payload']])
         except Exception:
             continue
 
@@ -87,8 +92,20 @@ def _query_pending_responses(storage) -> "pd.DataFrame":
 
     all_df = pd.concat(frames, ignore_index=True)
 
-    # For each run_id (= response_id), find the latest event by timestamp
-    latest = all_df.sort_values('timestamp').groupby('run_id').last().reset_index()
+    # Extract the OpenAI response_id from payload.data.response_id.
+    # Current schema: run_id = LangChain UUID, data.response_id = OpenAI resp_xxx.
+    # Fallback: run_id = OpenAI resp_xxx (older log files written before this change).
+    def _extract_resp_id(row):
+        try:
+            resp_id = _json.loads(row['payload']).get('data', {}).get('response_id')
+            return resp_id or row['run_id']
+        except Exception:
+            return row['run_id']
+
+    all_df['effective_response_id'] = all_df.apply(_extract_resp_id, axis=1)
+
+    # For each response, find the latest event by timestamp
+    latest = all_df.sort_values('timestamp').groupby('effective_response_id').last().reset_index()
 
     # Keep only non-terminal entries (responses still pending)
     pending = latest[~latest['event_type'].isin(_TERMINAL_RETRIEVAL_EVENT_TYPES)]
@@ -97,7 +114,7 @@ def _query_pending_responses(storage) -> "pd.DataFrame":
         return pd.DataFrame(columns=['response_id', 'custom_id'])
 
     return pd.DataFrame({
-        'response_id': pending['run_id'].values,
+        'response_id': pending['effective_response_id'].values,
         'custom_id': pending['custom_id'].values,
     })
 
@@ -274,6 +291,14 @@ async def retrieve_background_responses(
         response_id = row[cc.response_id]
         custom_id = row.get(cc.custom_id, "")
 
+        # Use the original LangChain run_id/parent_run_id when available (captured by
+        # _BackgroundRunIdCapture in Batch.run()) so that retrieval events share the
+        # same top-level run_id column as llm_start/llm_end, enabling simple JOINs.
+        # Fall back to response_id for backward compat when called without Batch.
+        llm_run_id = row.get('run_id') or response_id
+        llm_parent_run_id = row.get('parent_run_id') or ''
+        tags = list(row.get('tags') or [])
+
         # Skip if already processed
         if response_id in processed_ids:
             if rc.return_results:
@@ -285,25 +310,26 @@ async def retrieve_background_responses(
                 }
             return None
 
-        def _log(event_type: str, data: dict):
+        def _log(event_type: str, data: dict, raw: Optional[dict] = None):
             """Log a background retrieval event using the standard SCHEMA format.
 
             Delegates to logger._log_event() so all entries go through the same
             code path as regular ParquetLogger events, including _safe_json_dumps().
+            ``raw`` is optional; for completed events it should be the full response dict.
             """
             if logger:
                 payload = {
                     "event_type": event_type,
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                     "execution": {
-                        "run_id": response_id,
-                        "parent_run_id": "",
+                        "run_id": llm_run_id,
+                        "parent_run_id": llm_parent_run_id,
                         "custom_id": custom_id,
-                        "tags": [],
+                        "tags": tags,
                         "metadata": {}
                     },
                     "data": data,
-                    "raw": {}
+                    "raw": raw or {}
                 }
                 logger._log_event(payload)
 
@@ -361,7 +387,7 @@ async def retrieve_background_responses(
                     'error': last_error,
                     'error_type': 'retrieval_failed',
                     'attempts': rc.max_retries,
-                })
+                }, raw={'error': last_error})
                 failed_ids[response_id] = last_error
                 processed_ids.add(response_id)
                 if rc.return_results:
@@ -413,7 +439,7 @@ async def retrieve_background_responses(
                     'status': 'completed',
                     'retrieval_time': datetime.now(timezone.utc).isoformat(),
                     'poll_attempts': poll_attempt + 1,
-                })
+                }, raw=response_data)
                 processed_ids.add(response_id)
                 if rc.return_results:
                     return {'response_id': response_id, 'status': 'completed', 'openai_response': response_data, 'parsed_output': parsed_output, 'error': None}
@@ -428,7 +454,7 @@ async def retrieve_background_responses(
                     'error_type': response_status,
                     'openai_response': response_data,
                     'poll_attempts': poll_attempt + 1,
-                })
+                }, raw=response_data)
                 failed_ids[response_id] = error_msg
                 processed_ids.add(response_id)
                 if rc.return_results:
@@ -452,7 +478,7 @@ async def retrieve_background_responses(
             'error': error_msg,
             'error_type': 'poll_timeout',
             'poll_attempts': rc.max_poll_attempts,
-        })
+        }, raw={'error': error_msg})
         failed_ids[response_id] = error_msg
         processed_ids.add(response_id)
         if rc.return_results:

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, TYPE_CHECKING
 
 import pandas as pd
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.runnables import RunnableLambda
 
 from .logger import ParquetLogger
@@ -62,6 +63,36 @@ def _try_extract_id_from_exception(exc: BaseException) -> Optional[str]:
     if id_match and status_match and status_match.group(1) in _OPENAI_PENDING_STATUSES:
         return id_match.group(1)
     return None
+
+
+class _BackgroundRunIdCapture(BaseCallbackHandler):
+    """Captures LangChain run_id/parent_run_id for OpenAI background responses.
+
+    Added alongside ParquetLogger in Batch.run() so that retrieval events can use
+    the same run_id as the original llm_start/llm_end events, enabling a simple
+    ``WHERE run_id = X`` join across all event types in Parquet.
+
+    Works with ``with_structured_output()`` because ``on_llm_end`` fires before
+    the parser raises ``ValueError`` for queued (empty-content) responses.
+    """
+
+    def __init__(self):
+        super().__init__()
+        # Maps OpenAI response_id → {run_id, parent_run_id}
+        self.response_to_run: Dict[str, dict] = {}
+
+    def on_llm_end(self, response, *, run_id, parent_run_id=None, **kwargs):
+        for gen_list in response.generations:
+            for gen in gen_list:
+                msg = getattr(gen, 'message', None) or gen
+                meta = getattr(msg, 'response_metadata', {}) or {}
+                if meta.get('status') in _OPENAI_PENDING_STATUSES:
+                    resp_id = meta.get('id')
+                    if resp_id:
+                        self.response_to_run[resp_id] = {
+                            'run_id': str(run_id or ''),
+                            'parent_run_id': str(parent_run_id or ''),
+                        }
 
 
 def _parse_from_openai_response(response_dict: dict, schema: Type) -> Optional[Any]:
@@ -307,14 +338,18 @@ class Batch:
         )
         self.local_path.mkdir(parents=True, exist_ok=True)
 
-        # Background response IDs captured during run() — response_id → custom_id
-        self._background_response_ids: Dict[str, str] = {}
+        # Background response IDs captured during run().
+        # Maps response_id → {custom_id, run_id, parent_run_id, tags}
+        self._background_response_ids: Dict[str, dict] = {}
         # Structured output schema from the last run() — applied during retrieve()
         self._last_structured_output: Optional[Type] = None
 
     @property
-    def pending_response_ids(self) -> Dict[str, str]:
-        """Background response IDs captured during the last run() call (response_id → custom_id)."""
+    def pending_response_ids(self) -> Dict[str, dict]:
+        """Background response IDs captured during the last run() call.
+
+        Returns a dict of ``response_id → {custom_id, run_id, parent_run_id, tags}``.
+        """
         return dict(self._background_response_ids)
 
     def _build_logger_metadata(self, llm_config: LLMConfig, batch_size: int) -> dict:
@@ -407,6 +442,10 @@ class Batch:
         )
         _effective_return_results = self.processing_config.return_results or _will_extract_ids
 
+        # Captures LangChain run_id/parent_run_id for each background response so that
+        # retrieval events use the same run_id as the original llm_start/llm_end events.
+        id_capture = _BackgroundRunIdCapture()
+
         with ParquetLogger(
             log_dir=str(self.local_path),
             buffer_size=self.processing_config.buffer_size,
@@ -415,7 +454,7 @@ class Batch:
             event_types=self.processing_config.event_types,
             s3_config=self.resolved_s3_config,
         ) as logger:
-            llm = llm_config.create_llm(callbacks=[logger])
+            llm = llm_config.create_llm(callbacks=[logger, id_capture])
             results = await _batch_run(
                 df, llm,
                 prompt_col=self.column_config.prompt,
@@ -473,7 +512,17 @@ class Batch:
                                     (row.get(self.column_config.config) or {}).get('tags', [])
                                 )
                             )
-                            self._background_response_ids[response_id] = custom_id
+                            # Include original LangChain run_id/parent_run_id (captured by
+                            # id_capture.on_llm_end) so retrieval events share the same
+                            # run_id as llm_start/llm_end for seamless Parquet joins.
+                            run_info = id_capture.response_to_run.get(response_id, {})
+                            tags = list((row.get(self.column_config.config) or {}).get('tags', []))
+                            self._background_response_ids[response_id] = {
+                                'custom_id': custom_id,
+                                'run_id': run_info.get('run_id', ''),
+                                'parent_run_id': run_info.get('parent_run_id', ''),
+                                'tags': tags,
+                            }
                     except Exception as exc:
                         warnings.warn(
                             f"response_id_extractor raised {type(exc).__name__} for a row "
@@ -519,9 +568,12 @@ class Batch:
             df = pd.DataFrame([
                 {
                     self.column_config.response_id: rid,
-                    self.column_config.custom_id: cid,
+                    self.column_config.custom_id: entry['custom_id'],
+                    'run_id': entry.get('run_id', ''),
+                    'parent_run_id': entry.get('parent_run_id', ''),
+                    'tags': entry.get('tags', []),
                 }
-                for rid, cid in self._background_response_ids.items()
+                for rid, entry in self._background_response_ids.items()
             ])
             count_desc = f"{len(df)} captured response(s)"
         else:

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -3,10 +3,10 @@
 import asyncio
 import os
 import warnings
-from pathlib import Path
+from dataclasses import asdict, dataclass
 from datetime import date, datetime, timezone
-from dataclasses import asdict
-from typing import Any, Optional, TYPE_CHECKING, Type, List
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 import pandas as pd
 from langchain_core.runnables import RunnableLambda
@@ -19,7 +19,14 @@ from .config import (
 from .tagging import with_tags
 
 
-async def batch_run(
+@dataclass
+class BatchOutcome:
+    """Return value from Batch.run_and_retrieve() containing both processing and retrieval results."""
+    batch_results: Optional[List]
+    retrieval_results: Optional[pd.DataFrame]
+
+
+async def _batch_run(
     df: pd.DataFrame,
     llm: Any,
     prompt_col: str = "prompt",
@@ -32,10 +39,9 @@ async def batch_run(
     row_timeout: Optional[float] = None,
 ) -> Optional[list]:
     """
-    Low-level async batch processing for DataFrames.
+    Internal async batch processing engine for DataFrames.
 
-    **Most users should use batch_process() instead**, which includes automatic logging.
-    Use batch_run() only when you need direct control over logging.
+    **Most users should use Batch instead**, which includes automatic logging.
 
     Args:
         df: DataFrame with prepared data
@@ -52,15 +58,6 @@ async def batch_run(
 
     Returns:
         List of results in same order as DataFrame rows, or None if return_results=False
-
-    Example:
-        >>> # When you already have logging configured:
-        >>> with ParquetLogger('./logs') as logger:
-        >>>     llm.callbacks = [logger]
-        >>>     results = await batch_run(df, llm, max_concurrency=100)
-        >>>
-        >>> # For most users, use batch_process() instead:
-        >>> results = await batch_process(df)  # Logging handled automatically
     """
     # Suppress Pydantic serialization warnings globally so it covers
     # LangChain/OpenAI SDK internals calling model_dump() during ainvoke()
@@ -95,24 +92,19 @@ async def batch_run(
                 )
             else:
                 result = await llm.ainvoke(**invoke_kwargs)
-            completed_count += 1
-            if show_progress and (completed_count % progress_interval == 0 or completed_count == total_count):
-                print(f"  Processed {completed_count}/{total_count} rows ({100 * completed_count // total_count}%)")
             return result
         except asyncio.TimeoutError:
-            completed_count += 1
-            if show_progress and (completed_count % progress_interval == 0 or completed_count == total_count):
-                print(f"  Processed {completed_count}/{total_count} rows ({100 * completed_count // total_count}%)")
             if return_exceptions:
                 return TimeoutError(f"Row timed out after {row_timeout}s")
             raise TimeoutError(f"Row timed out after {row_timeout}s")
         except Exception as e:
-            completed_count += 1
-            if show_progress and (completed_count % progress_interval == 0 or completed_count == total_count):
-                print(f"  Processed {completed_count}/{total_count} rows ({100 * completed_count // total_count}%)")
             if return_exceptions:
                 return e
             raise
+        finally:
+            completed_count += 1
+            if show_progress and (completed_count % progress_interval == 0 or completed_count == total_count):
+                print(f"  Processed {completed_count}/{total_count} rows ({100 * completed_count // total_count}%)")
 
     # Create runner and process batch
     runner = RunnableLambda(process_row)
@@ -141,7 +133,7 @@ def _build_storage_paths(
 ) -> tuple:
     """Resolve local path and S3 config from job/storage configs.
 
-    Shared by batch_process() and retrieve_batch_responses() so both functions
+    Shared by Batch and retrieve_background_responses() so both functions
     write to the same directory structure.
 
     Returns:
@@ -160,14 +152,16 @@ def _build_storage_paths(
 
     local_path = Path(storage_config.output_dir) / storage_config.path_template.format(**template_vars)
 
-    # Check for S3 bucket in environment if not configured
-    if not storage_config.s3_config and os.environ.get('LANGCHAIN_S3_BUCKET'):
-        storage_config.s3_config = S3Config(bucket=os.environ['LANGCHAIN_S3_BUCKET'])
+    # Check for S3 bucket in environment if not configured — use a local variable,
+    # never mutate the caller's storage_config object
+    s3_config = storage_config.s3_config
+    if not s3_config and os.environ.get('LANGCHAIN_S3_BUCKET'):
+        s3_config = S3Config(bucket=os.environ['LANGCHAIN_S3_BUCKET'])
 
     resolved_s3_config = None
-    if storage_config.s3_config:
+    if s3_config:
         import copy
-        resolved_s3_config = copy.copy(storage_config.s3_config)
+        resolved_s3_config = copy.copy(s3_config)
         base_prefix = resolved_s3_config.prefix.rstrip('/')
         formatted_path = storage_config.path_template.format(**template_vars).lstrip('/')
         resolved_s3_config.prefix = f"{base_prefix}/{formatted_path}/" if base_prefix else f"{formatted_path}/"
@@ -175,244 +169,299 @@ def _build_storage_paths(
     return local_path, resolved_s3_config
 
 
-async def batch_process(
-    df: pd.DataFrame,
-    llm_config: LLMConfig,
-    job_config: Optional[JobConfig] = None,
-    storage_config: Optional[StorageConfig] = None,
-    processing_config: Optional[ProcessingConfig] = None,
-    column_config: Optional[ColumnConfig] = None,
-) -> Optional[List]:
+class Batch:
     """
-    Batch process DataFrame through LLM with automatic logging to Parquet.
+    Orchestrates a complete batch processing job lifecycle.
+
+    Resolves storage paths once, then provides ``run()``, ``retrieve()``, and
+    ``run_and_retrieve()`` methods that share the same paths and configuration.
+    Background response IDs captured during ``run()`` are automatically available
+    to ``retrieve()``, enabling a seamless run-then-retrieve workflow.
 
     Args:
-        df: DataFrame with prepared data
-        llm_config: LLM configuration including class, kwargs, and structured output
-        job_config: Job metadata configuration
-        storage_config: Storage configuration for output files
-        processing_config: Processing configuration for batch operations
-        column_config: DataFrame column name configuration
+        job_config: Job metadata (category, subcategory, version, environment).
+        storage_config: Storage paths and optional S3 configuration.
+        processing_config: Concurrency, buffer size, and other processing settings.
+        column_config: DataFrame column name mapping.
 
-    Returns:
-        List of results if processing_config.return_results=True, None otherwise
+    Example — standard batch (no background processing)::
 
-    Examples:
-        >>> # Simple usage with LLMConfig
-        >>> from langchain_openai import ChatOpenAI
-        >>> await batch_process(
-        ...     df,
-        ...     llm_config=LLMConfig(
-        ...         llm_class=ChatOpenAI,
-        ...         llm_kwargs={'model': 'gpt-4', 'temperature': 0.7}
-        ...     ),
-        ...     job_config=JobConfig(category='analysis', version='2.0')
+        >>> batch = Batch(
+        ...     job_config=JobConfig(category="analysis", version="1.0"),
+        ...     storage_config=StorageConfig(output_dir="./logs"),
         ... )
+        >>> results = await batch.run(df, llm_config)
 
-        >>> # With structured output
-        >>> from pydantic import BaseModel
-        >>> class EmailInfo(BaseModel):
-        ...     email: str
-        ...     valid: bool
-        >>>
-        >>> await batch_process(
-        ...     df,
-        ...     llm_config=LLMConfig(
-        ...         llm_class=ChatOpenAI,
-        ...         llm_kwargs={'model': 'gpt-4'},
-        ...         structured_output=EmailInfo
-        ...     ),
-        ...     job_config=JobConfig(category='email_validation')
+    Example — background processing (run then retrieve)::
+
+        >>> def extract_response_id(result, row):
+        ...     return getattr(result, 'response_metadata', {}).get('id')
+        ...
+        >>> batch = Batch(
+        ...     job_config=JobConfig(category="analysis"),
+        ...     storage_config=StorageConfig(output_dir="./logs"),
         ... )
-    """
-    # Suppress Pydantic serialization warnings globally
-    warnings.filterwarnings("ignore", category=UserWarning, module=r"^pydantic")
-
-    # Initialize configs with defaults if not provided
-    job_config = job_config or JobConfig()
-    storage_config = storage_config or StorageConfig()
-    processing_config = processing_config or ProcessingConfig()
-    column_config = column_config or ColumnConfig()
-
-    # Validate DataFrame has required columns
-    if column_config.prompt not in df.columns:
-        raise ValueError(f"DataFrame missing required column: {column_config.prompt}")
-
-    # LLM will be created inside the logger context with callbacks
-
-    # Resolve local and S3 paths
-    local_path, resolved_s3_config = _build_storage_paths(job_config, storage_config)
-    local_path.mkdir(parents=True, exist_ok=True)
-
-    # Build comprehensive logger metadata
-    logger_metadata = {
-        # Legacy flat fields (for backward compatibility in queries)
-        'job_category': job_config.category,
-        'job_subcategory': job_config.subcategory,
-        'environment': job_config.environment,
-        'job_description': job_config.description,
-        'job_version': job_config.version,
-
-        # Complete batch-level configs (NEW structure)
-        'batch_config': {
-            'job': asdict(job_config) if job_config else None,
-            'storage': {
-                'output_dir': storage_config.output_dir,
-                'path_template': storage_config.path_template,
-                's3': asdict(resolved_s3_config) if resolved_s3_config else None
-            },
-            'processing': asdict(processing_config) if processing_config else None,
-            'column': asdict(column_config) if column_config else None,
-            'llm': llm_config.to_metadata_dict(),
-        },
-
-        # Batch execution metadata
-        'batch_started_at': datetime.now(timezone.utc).isoformat(),
-        'batch_size': len(df),
-
-        # Custom metadata from job_config (if any)
-        **(job_config.metadata or {})
-    }
-
-    # Print status messages
-    if processing_config.show_progress:
-        print(f"🚀 Starting processing of {len(df)} rows...")
-        print(f"📁 Local output: {local_path}")
-        if resolved_s3_config:
-            print(f"☁️  S3 upload: s3://{resolved_s3_config.bucket}/{resolved_s3_config.prefix}")
-
-    # Process with context manager for automatic cleanup
-    with ParquetLogger(
-        log_dir=str(local_path),
-        buffer_size=processing_config.buffer_size,
-        logger_metadata=logger_metadata,
-        partition_on=processing_config.partition_on,
-        event_types=processing_config.event_types,
-        s3_config=resolved_s3_config,
-    ) as logger:
-        # Create LLM with logger as callback
-        llm = llm_config.create_llm(callbacks=[logger])
-
-        # Run batch processing
-        results = await batch_run(
-            df, llm,
-            prompt_col=column_config.prompt,
-            config_col=column_config.config,
-            tools_col=column_config.tools,
-            max_concurrency=processing_config.max_concurrency,
-            show_progress=processing_config.show_progress,
-            return_exceptions=processing_config.return_exceptions,
-            return_results=processing_config.return_results,
-            row_timeout=processing_config.row_timeout,
-        )
-
-    # Print completion message
-    if processing_config.show_progress:
-        print("✅ Processing complete!")
-        print(f"📍 Local files: {local_path}")
-        if resolved_s3_config:
-            print(f"☁️  S3 location: s3://{resolved_s3_config.bucket}/{resolved_s3_config.prefix}")
-
-    return results
-
-
-async def retrieve_batch_responses(
-    df: pd.DataFrame,
-    openai_client=None,
-    job_config: Optional[JobConfig] = None,
-    storage_config: Optional[StorageConfig] = None,
-    retrieval_config: Optional[RetrievalConfig] = None,
-    response_id_col: str = "response_id",
-    custom_id_col: str = "custom_id",
-) -> Optional[pd.DataFrame]:
-    """
-    Retrieve OpenAI background responses and log them to the same Parquet location
-    as the original batch_process() call.
-
-    Polls each response until its status is "completed" (or a terminal error/cancellation),
-    logging each pending check and the final outcome. Pass the same ``job_config`` and
-    ``storage_config`` you used in ``batch_process()`` to have all events land in one place.
-
-    Args:
-        df: DataFrame with response IDs (and optionally custom IDs) to retrieve
-        openai_client: OpenAI async client. If None, creates ``AsyncOpenAI()`` automatically
-            using ``OPENAI_API_KEY`` from the environment (same behaviour as LangChain's ChatOpenAI).
-        job_config: Job metadata — use the same values as the original batch_process() call
-        storage_config: Storage paths — use the same values as the original batch_process() call
-        retrieval_config: Polling and execution settings (poll_interval, max_poll_attempts, etc.)
-        response_id_col: Column name containing OpenAI response IDs (default: "response_id")
-        custom_id_col: Column name containing your custom row IDs (default: "custom_id")
-
-    Returns:
-        DataFrame with columns: response_id, status, openai_response, error
-        (or None if retrieval_config.return_results=False)
-
-    Example:
-        >>> from openai import AsyncOpenAI
-        >>> import langchain_callback_parquet_logger as lcpl
-        >>>
-        >>> results = await lcpl.retrieve_batch_responses(
-        ...     df,  # DataFrame with response_id and custom_id columns
+        >>> outcome = await batch.run_and_retrieve(
+        ...     df, llm_config,
         ...     openai_client=AsyncOpenAI(),
-        ...     job_config=lcpl.JobConfig(
-        ...         category=job_category,
-        ...         subcategory=job_subcategory,
-        ...         version=job_version,
-        ...         environment="hex_notebook",
-        ...     ),
-        ...     storage_config=lcpl.StorageConfig(
-        ...         output_dir="./batch_logs",
-        ...         path_template="{job_category}/{job_subcategory}/v{job_version_safe}",
-        ...         s3_config=lcpl.S3Config(bucket="my-bucket", on_failure="error"),
-        ...     ),
-        ...     retrieval_config=lcpl.RetrievalConfig(
-        ...         poll_interval=30.0,
-        ...         max_poll_attempts=40,
-        ...         checkpoint_file="./retrieval_checkpoint.parquet",
-        ...     ),
+        ...     response_id_extractor=extract_response_id,
         ... )
+        >>> batch_results = outcome.batch_results
+        >>> retrieval_df = outcome.retrieval_results
+
+    Example — inspect batch results before retrieval::
+
+        >>> batch_results = await batch.run(df, llm_config,
+        ...                                  response_id_extractor=extract_response_id)
+        >>> print(f"Captured {len(batch.pending_response_ids)} background response(s)")
+        >>> retrieval_df = await batch.retrieve(openai_client=AsyncOpenAI())
     """
-    from .background_retrieval import retrieve_background_responses
 
-    job_config = job_config or JobConfig()
-    storage_config = storage_config or StorageConfig()
-    retrieval_config = retrieval_config or RetrievalConfig()
+    def __init__(
+        self,
+        job_config: Optional[JobConfig] = None,
+        storage_config: Optional[StorageConfig] = None,
+        processing_config: Optional[ProcessingConfig] = None,
+        column_config: Optional[ColumnConfig] = None,
+    ):
+        self.job_config = job_config or JobConfig()
+        self.storage_config = storage_config or StorageConfig()
+        self.processing_config = processing_config or ProcessingConfig()
+        self.column_config = column_config or ColumnConfig()
 
-    local_path, resolved_s3_config = _build_storage_paths(job_config, storage_config)
-    local_path.mkdir(parents=True, exist_ok=True)
-
-    if retrieval_config.show_progress:
-        print(f"🔍 Retrieving {len(df)} responses...")
-        print(f"📁 Local output: {local_path}")
-        if resolved_s3_config:
-            print(f"☁️  S3 upload: s3://{resolved_s3_config.bucket}/{resolved_s3_config.prefix}")
-
-    with ParquetLogger(
-        log_dir=str(local_path),
-        buffer_size=1000,
-        partition_on="date",
-        s3_config=resolved_s3_config,
-    ) as logger:
-        results = await retrieve_background_responses(
-            df=df,
-            openai_client=openai_client,
-            logger=logger,
-            response_id_col=response_id_col,
-            custom_id_col=custom_id_col,
-            batch_size=retrieval_config.batch_size,
-            max_retries=retrieval_config.max_retries,
-            timeout=retrieval_config.timeout,
-            poll_interval=retrieval_config.poll_interval,
-            max_poll_attempts=retrieval_config.max_poll_attempts,
-            show_progress=retrieval_config.show_progress,
-            checkpoint_file=retrieval_config.checkpoint_file,
-            return_results=retrieval_config.return_results,
+        # Resolve storage paths once — shared by run() and retrieve()
+        self.local_path, self.resolved_s3_config = _build_storage_paths(
+            self.job_config, self.storage_config
         )
+        self.local_path.mkdir(parents=True, exist_ok=True)
 
-    if retrieval_config.show_progress:
-        print("✅ Retrieval complete!")
-        print(f"📍 Local files: {local_path}")
-        if resolved_s3_config:
-            print(f"☁️  S3 location: s3://{resolved_s3_config.bucket}/{resolved_s3_config.prefix}")
+        # Background response IDs captured during run() — response_id → custom_id
+        self._background_response_ids: Dict[str, str] = {}
 
-    return results
+    @property
+    def pending_response_ids(self) -> Dict[str, str]:
+        """Background response IDs captured during the last run() call (response_id → custom_id)."""
+        return dict(self._background_response_ids)
+
+    def _build_logger_metadata(self, llm_config: LLMConfig, batch_size: int) -> dict:
+        """Build the comprehensive logger metadata dict for a run."""
+        return {
+            # Complete batch-level configs
+            'batch_config': {
+                'job': asdict(self.job_config),
+                'storage': {
+                    'output_dir': self.storage_config.output_dir,
+                    'path_template': self.storage_config.path_template,
+                    's3': asdict(self.resolved_s3_config) if self.resolved_s3_config else None
+                },
+                'processing': asdict(self.processing_config),
+                'column': asdict(self.column_config),
+                'llm': llm_config.to_metadata_dict(),
+            },
+
+            # Batch execution metadata
+            'batch_started_at': datetime.now(timezone.utc).isoformat(),
+            'batch_size': batch_size,
+
+            # Custom metadata from job_config (if any)
+            **(self.job_config.metadata or {})
+        }
+
+    def _print_start(self, action: str, count: int) -> None:
+        """Print job-start status lines."""
+        print(f"{action} {count} rows...")
+        print(f"📁 Local output: {self.local_path}")
+        if self.resolved_s3_config:
+            print(f"☁️  S3 upload: s3://{self.resolved_s3_config.bucket}/{self.resolved_s3_config.prefix}")
+
+    def _print_end(self, action: str) -> None:
+        """Print job-completion status lines."""
+        print(f"✅ {action} complete!")
+        print(f"📍 Local files: {self.local_path}")
+        if self.resolved_s3_config:
+            print(f"☁️  S3 location: s3://{self.resolved_s3_config.bucket}/{self.resolved_s3_config.prefix}")
+
+    async def run(
+        self,
+        df: pd.DataFrame,
+        llm_config: LLMConfig,
+        response_id_extractor: Optional[Callable[[Any, dict], Optional[str]]] = None,
+    ) -> Optional[List]:
+        """
+        Run batch processing with automatic Parquet logging.
+
+        After _batch_run() completes, any result for which ``response_id_extractor``
+        returns a non-None string is treated as a background (queued) response.
+        Those response IDs are stored in ``self._background_response_ids`` and
+        are automatically used by ``retrieve()``.
+
+        Args:
+            df: DataFrame with one row per LLM request.
+            llm_config: LLM class and kwargs to use for the batch.
+            response_id_extractor: Optional callable ``(result, row_dict) -> str | None``
+                that extracts a background response ID from a result object.
+                Return None for synchronous (non-background) results.
+
+        Returns:
+            List of results if processing_config.return_results=True, None otherwise.
+        """
+        # Suppress Pydantic serialization warnings globally
+        warnings.filterwarnings("ignore", category=UserWarning, module=r"^pydantic")
+
+        if self.column_config.prompt not in df.columns:
+            raise ValueError(f"DataFrame missing required column: {self.column_config.prompt}")
+
+        logger_metadata = self._build_logger_metadata(llm_config, len(df))
+
+        if self.processing_config.show_progress:
+            self._print_start("🚀 Starting processing of", len(df))
+
+        with ParquetLogger(
+            log_dir=str(self.local_path),
+            buffer_size=self.processing_config.buffer_size,
+            logger_metadata=logger_metadata,
+            partition_on=self.processing_config.partition_on,
+            event_types=self.processing_config.event_types,
+            s3_config=self.resolved_s3_config,
+        ) as logger:
+            llm = llm_config.create_llm(callbacks=[logger])
+            results = await _batch_run(
+                df, llm,
+                prompt_col=self.column_config.prompt,
+                config_col=self.column_config.config,
+                tools_col=self.column_config.tools,
+                max_concurrency=self.processing_config.max_concurrency,
+                show_progress=self.processing_config.show_progress,
+                return_exceptions=self.processing_config.return_exceptions,
+                return_results=self.processing_config.return_results,
+                row_timeout=self.processing_config.row_timeout,
+            )
+
+        # Capture background response IDs from results
+        if response_id_extractor and results:
+            self._background_response_ids = {}
+            rows = df.to_dict('records')
+            for result, row in zip(results, rows):
+                if result is None or isinstance(result, (Exception, BaseException)):
+                    continue
+                try:
+                    response_id = response_id_extractor(result, row)
+                    if response_id:
+                        custom_id = row.get(self.column_config.custom_id, '')
+                        self._background_response_ids[response_id] = custom_id
+                except Exception:
+                    pass
+
+        if self.processing_config.show_progress:
+            self._print_end("Processing")
+
+        return results
+
+    async def retrieve(
+        self,
+        openai_client=None,
+        retrieval_config: Optional[RetrievalConfig] = None,
+    ) -> Optional[pd.DataFrame]:
+        """
+        Retrieve background responses and log them to the same Parquet location.
+
+        Uses response IDs captured during ``run()`` if available, otherwise
+        auto-discovers pending responses from the local Parquet files (useful
+        for cross-process resume when a process restarts after a crash).
+
+        Args:
+            openai_client: OpenAI async client. Auto-creates ``AsyncOpenAI()`` if None.
+            retrieval_config: Polling and execution settings.
+
+        Returns:
+            DataFrame with columns: response_id, status, openai_response, error
+            (or None if retrieval_config.return_results=False).
+        """
+        from .background_retrieval import retrieve_background_responses, _query_pending_responses
+        from .storage import LocalStorage, S3Storage
+
+        rc = retrieval_config or RetrievalConfig()
+
+        # Build df from in-memory captured IDs, or auto-discover from storage
+        if self._background_response_ids:
+            df = pd.DataFrame([
+                {
+                    self.column_config.response_id: rid,
+                    self.column_config.custom_id: cid,
+                }
+                for rid, cid in self._background_response_ids.items()
+            ])
+            count_desc = f"{len(df)} captured response(s)"
+        else:
+            # Auto-discover from Parquet files using this batch's storage
+            if rc.source == "s3" and self.resolved_s3_config:
+                read_storage = S3Storage(self.resolved_s3_config)
+            else:
+                read_storage = LocalStorage(self.local_path)
+
+            df = _query_pending_responses(read_storage)
+            if df.empty:
+                print("No pending responses found in storage.")
+                return pd.DataFrame() if rc.return_results else None
+            count_desc = f"{len(df)} auto-discovered response(s)"
+
+        if rc.show_progress:
+            self._print_start(f"🔍 Retrieving {count_desc} —", 0)
+
+        with ParquetLogger(
+            log_dir=str(self.local_path),
+            buffer_size=1000,
+            partition_on=self.processing_config.partition_on,
+            s3_config=self.resolved_s3_config,
+        ) as logger:
+            results = await retrieve_background_responses(
+                df=df,
+                openai_client=openai_client,
+                logger=logger,
+                retrieval_config=rc,
+                column_config=self.column_config,
+            )
+
+        if rc.show_progress:
+            self._print_end("Retrieval")
+
+        return results
+
+    async def run_and_retrieve(
+        self,
+        df: pd.DataFrame,
+        llm_config: LLMConfig,
+        openai_client=None,
+        retrieval_config: Optional[RetrievalConfig] = None,
+        response_id_extractor: Optional[Callable[[Any, dict], Optional[str]]] = None,
+    ) -> BatchOutcome:
+        """
+        Run batch processing then immediately retrieve any background responses.
+
+        This is the primary method for the background-processing workflow.
+        After the batch completes, background response IDs captured via
+        ``response_id_extractor`` are polled automatically.
+
+        Args:
+            df: DataFrame with one row per LLM request.
+            llm_config: LLM class and kwargs to use for the batch.
+            openai_client: OpenAI async client for retrieval. Auto-created if None.
+            retrieval_config: Polling and execution settings for retrieval.
+            response_id_extractor: Callable ``(result, row_dict) -> str | None``
+                that extracts a background response ID from a result object.
+
+        Returns:
+            BatchOutcome with:
+                - ``batch_results``: list of LLM results (or None)
+                - ``retrieval_results``: DataFrame of retrieved responses (or None)
+        """
+        batch_results = await self.run(
+            df, llm_config, response_id_extractor=response_id_extractor
+        )
+        retrieval_results = await self.retrieve(
+            openai_client=openai_client, retrieval_config=retrieval_config
+        )
+        return BatchOutcome(
+            batch_results=batch_results,
+            retrieval_results=retrieval_results,
+        )

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -328,6 +328,12 @@ class Batch:
         Returns:
             List of results if processing_config.return_results=True, None otherwise.
         """
+        # Always reset at the start of each run() so stale IDs from a prior call can
+        # never leak into retrieve().  Calling run() twice with ChatOpenAI would
+        # silently overwrite the first batch's IDs; running a regular (non-background)
+        # LLM after a background LLM would leave old IDs in place indefinitely.
+        self._background_response_ids = {}
+
         # Suppress Pydantic serialization warnings globally
         warnings.filterwarnings("ignore", category=UserWarning, module=r"^pydantic")
 
@@ -369,28 +375,29 @@ class Batch:
                 row_timeout=self.processing_config.row_timeout,
             )
 
-        # Auto-detect extractor for known background-capable OpenAI LLM classes
-        if response_id_extractor is None and llm_config.llm_class.__name__ in _OPENAI_BACKGROUND_CLASSES:
-            response_id_extractor = _openai_response_id_extractor
+            # Auto-detect extractor for known background-capable OpenAI LLM classes.
+            # ID capture is intentionally inside the 'with' block so that
+            # _background_response_ids is populated even when flush() raises an S3 error
+            # on context exit — the LLM calls already succeeded, so the IDs are valid.
+            if response_id_extractor is None and llm_config.llm_class.__name__ in _OPENAI_BACKGROUND_CLASSES:
+                response_id_extractor = _openai_response_id_extractor
 
-        # Capture background response IDs from results
-        if response_id_extractor and results:
-            self._background_response_ids = {}
-            rows = df.to_dict('records')
-            for result, row in zip(results, rows):
-                if result is None or isinstance(result, (Exception, BaseException)):
-                    continue
-                try:
-                    response_id = response_id_extractor(result, row)
-                    if response_id:
-                        custom_id = row.get(self.column_config.custom_id, '')
-                        self._background_response_ids[response_id] = custom_id
-                except Exception as exc:
-                    warnings.warn(
-                        f"response_id_extractor raised {type(exc).__name__} for a row "
-                        f"and was skipped: {exc}",
-                        stacklevel=2,
-                    )
+            if response_id_extractor and results:
+                rows = df.to_dict('records')
+                for result, row in zip(results, rows):
+                    if result is None or isinstance(result, (Exception, BaseException)):
+                        continue
+                    try:
+                        response_id = response_id_extractor(result, row)
+                        if response_id:
+                            custom_id = row.get(self.column_config.custom_id, '')
+                            self._background_response_ids[response_id] = custom_id
+                    except Exception as exc:
+                        warnings.warn(
+                            f"response_id_extractor raised {type(exc).__name__} for a row "
+                            f"and was skipped: {exc}",
+                            stacklevel=2,
+                        )
 
         if self.processing_config.show_progress:
             self._print_end("Processing")
@@ -458,9 +465,23 @@ class Batch:
             if self.resolved_s3_config:
                 print(f"☁️  S3 upload: s3://{self.resolved_s3_config.bucket}/{self.resolved_s3_config.prefix}")
 
+        retrieval_metadata = {
+            'batch_config': {
+                'job': asdict(self.job_config),
+                'storage': {
+                    'output_dir': self.storage_config.output_dir,
+                    'path_template': self.storage_config.path_template,
+                    's3': asdict(self.resolved_s3_config) if self.resolved_s3_config else None,
+                },
+            },
+            'retrieval_started_at': datetime.now(timezone.utc).isoformat(),
+            **(self.job_config.metadata or {}),
+        }
+
         with ParquetLogger(
             log_dir=str(self.local_path),
             buffer_size=1000,
+            logger_metadata=retrieval_metadata,
             partition_on=self.processing_config.partition_on,
             s3_config=self.resolved_s3_config,
         ) as logger:

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -562,6 +562,7 @@ class Batch:
         openai_client=None,
         retrieval_config: Optional[RetrievalConfig] = None,
         s3_path: Optional[str] = None,
+        df: Optional[pd.DataFrame] = None,
     ) -> Optional[pd.DataFrame]:
         """
         Retrieve background responses and log them to the same Parquet location.
@@ -577,6 +578,11 @@ class Batch:
                 pending responses are discovered from that S3 location instead of the
                 batch's own storage. Useful for cross-process resume without a live
                 ``Batch`` object.
+            df: Optional DataFrame of response IDs to retrieve directly, bypassing all
+                auto-discovery. Required column: ``response_id`` (name respects
+                ``column_config.response_id``). Optional columns: ``custom_id``,
+                ``run_id``, ``parent_run_id``, ``tags``. Takes priority over all other
+                discovery paths including ``s3_path`` and in-memory IDs.
 
         Returns:
             DataFrame with columns: response_id, status, openai_response, error
@@ -587,8 +593,10 @@ class Batch:
 
         rc = retrieval_config or self.retrieval_config
 
-        # Build df from in-memory captured IDs, or auto-discover from storage
-        if s3_path is not None:
+        # Build df from explicit input, in-memory IDs, or auto-discovery
+        if df is not None:
+            count_desc = f"{len(df)} response(s) from provided DataFrame"
+        elif s3_path is not None:
             # s3_path overrides all other discovery — read pending from S3
             bucket, prefix = _parse_s3_uri(s3_path)
             read_storage = S3Storage(S3Config(bucket=bucket, prefix=prefix))

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -420,6 +420,9 @@ class Batch:
             ])
             count_desc = f"{len(df)} captured response(s)"
         else:
+            # 'memory' source means use only in-memory IDs — skip storage discovery
+            if rc.source == 'memory':
+                return pd.DataFrame() if rc.return_results else None
             # Auto-discover from Parquet files using this batch's storage
             if rc.source == "s3" and self.resolved_s3_config:
                 read_storage = S3Storage(self.resolved_s3_config)
@@ -485,6 +488,9 @@ class Batch:
         batch_results = await self.run(
             df, llm_config, response_id_extractor=response_id_extractor
         )
+        # If run() captured no background IDs (e.g. synchronous LLM), skip retrieve
+        if not self._background_response_ids:
+            return BatchOutcome(batch_results=batch_results, retrieval_results=None)
         retrieval_results = await self.retrieve(
             openai_client=openai_client,
             retrieval_config=retrieval_config or self.retrieval_config,

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -339,6 +339,15 @@ class Batch:
         if self.processing_config.show_progress:
             self._print_start("🚀 Starting processing of", len(df))
 
+        # If ID extraction will be needed, hold results in memory regardless of
+        # return_results — background results are small (just response_id objects)
+        # and this prevents a silent failure when return_results=False.
+        _will_extract_ids = (
+            response_id_extractor is not None or
+            llm_config.llm_class.__name__ in _OPENAI_BACKGROUND_CLASSES
+        )
+        _effective_return_results = self.processing_config.return_results or _will_extract_ids
+
         with ParquetLogger(
             log_dir=str(self.local_path),
             buffer_size=self.processing_config.buffer_size,
@@ -356,7 +365,7 @@ class Batch:
                 max_concurrency=self.processing_config.max_concurrency,
                 show_progress=self.processing_config.show_progress,
                 return_exceptions=self.processing_config.return_exceptions,
-                return_results=self.processing_config.return_results,
+                return_results=_effective_return_results,
                 row_timeout=self.processing_config.row_timeout,
             )
 
@@ -376,12 +385,19 @@ class Batch:
                     if response_id:
                         custom_id = row.get(self.column_config.custom_id, '')
                         self._background_response_ids[response_id] = custom_id
-                except Exception:
-                    pass
+                except Exception as exc:
+                    warnings.warn(
+                        f"response_id_extractor raised {type(exc).__name__} for a row "
+                        f"and was skipped: {exc}",
+                        stacklevel=2,
+                    )
 
         if self.processing_config.show_progress:
             self._print_end("Processing")
 
+        # Respect the original return_results setting for the caller
+        if not self.processing_config.return_results:
+            return None
         return results
 
     async def retrieve(
@@ -431,12 +447,16 @@ class Batch:
 
             df = _query_pending_responses(read_storage)
             if df.empty:
-                print("No pending responses found in storage.")
+                if rc.show_progress:
+                    print("No pending responses found in storage.")
                 return pd.DataFrame() if rc.return_results else None
             count_desc = f"{len(df)} auto-discovered response(s)"
 
         if rc.show_progress:
-            self._print_start(f"🔍 Retrieving {count_desc} —", 0)
+            print(f"🔍 Retrieving {count_desc}...")
+            print(f"📁 Local output: {self.local_path}")
+            if self.resolved_s3_config:
+                print(f"☁️  S3 upload: s3://{self.resolved_s3_config.bucket}/{self.resolved_s3_config.prefix}")
 
         with ParquetLogger(
             log_dir=str(self.local_path),

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -2,11 +2,12 @@
 
 import asyncio
 import os
+import re
 import warnings
 from dataclasses import asdict, dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Type, TYPE_CHECKING
 
 import pandas as pd
 from langchain_core.runnables import RunnableLambda
@@ -45,6 +46,54 @@ def _openai_response_id_extractor(result: Any, row: dict) -> Optional[str]:
     if meta.get('status') not in _OPENAI_PENDING_STATUSES:
         return None
     return meta.get('id')
+
+
+def _try_extract_id_from_exception(exc: BaseException) -> Optional[str]:
+    """Extract a pending background response ID from a structured-output ValueError.
+
+    When ``with_structured_output()`` wraps a background LLM, queued responses have
+    no content, causing LangChain to raise ValueError.  The stringified exception
+    contains the full response metadata (id + status), so we recover the ID via regex.
+    Returns None for any other exception type or non-pending status.
+    """
+    msg = str(exc)
+    id_match = re.search(r"\bid='(resp_[A-Za-z0-9]+)'", msg)
+    status_match = re.search(r"'status':\s*'([^']+)'", msg)
+    if id_match and status_match and status_match.group(1) in _OPENAI_PENDING_STATUSES:
+        return id_match.group(1)
+    return None
+
+
+def _parse_from_openai_response(response_dict: dict, schema: Type) -> Optional[Any]:
+    """Parse structured output from a serialized OpenAI Response dict.
+
+    ``retrieve_background_responses()`` stores the response as
+    ``model_dump(mode='json')``, so the JSON text for structured-output responses
+    lives at ``output[0].content[0].text`` (type == 'output_text').
+    Returns a validated Pydantic instance, or None on any failure.
+    """
+    if not response_dict or not isinstance(response_dict, dict):
+        return None
+    # Try convenience property first, then navigate the output array
+    text: Optional[str] = response_dict.get('output_text')
+    if not text:
+        for item in response_dict.get('output', []):
+            for content in item.get('content', []):
+                if content.get('type') == 'output_text':
+                    text = content.get('text')
+                    break
+            if text:
+                break
+    if not text:
+        return None
+    try:
+        return schema.model_validate_json(text)
+    except Exception:
+        import json as _json
+        try:
+            return schema(**_json.loads(text))
+        except Exception:
+            return None
 
 
 async def _batch_run(
@@ -260,6 +309,8 @@ class Batch:
 
         # Background response IDs captured during run() — response_id → custom_id
         self._background_response_ids: Dict[str, str] = {}
+        # Structured output schema from the last run() — applied during retrieve()
+        self._last_structured_output: Optional[Type] = None
 
     @property
     def pending_response_ids(self) -> Dict[str, str]:
@@ -333,6 +384,8 @@ class Batch:
         # silently overwrite the first batch's IDs; running a regular (non-background)
         # LLM after a background LLM would leave old IDs in place indefinitely.
         self._background_response_ids = {}
+        # Capture the structured output schema so retrieve() can parse responses.
+        self._last_structured_output = llm_config.structured_output
 
         # Suppress Pydantic serialization warnings globally
         warnings.filterwarnings("ignore", category=UserWarning, module=r"^pydantic")
@@ -382,13 +435,34 @@ class Batch:
             if response_id_extractor is None and llm_config.llm_class.__name__ in _OPENAI_BACKGROUND_CLASSES:
                 response_id_extractor = _openai_response_id_extractor
 
+            # Warn when structured_output + background LLM are combined — the parser
+            # cannot run until retrieval, so batch_results will contain ValueErrors.
+            if (llm_config.structured_output
+                    and llm_config.llm_class.__name__ in _OPENAI_BACKGROUND_CLASSES):
+                warnings.warn(
+                    "structured_output is set with a background-capable LLM. "
+                    "Structured output parsing requires a completed response and cannot "
+                    "run until retrieval. batch_results will contain ValueError exceptions "
+                    "(normal for background mode) — retrieve() will apply the schema and "
+                    "return a parsed_output column.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
             if response_id_extractor and results:
                 rows = df.to_dict('records')
                 for result, row in zip(results, rows):
-                    if result is None or isinstance(result, (Exception, BaseException)):
-                        continue
                     try:
-                        response_id = response_id_extractor(result, row)
+                        if result is None:
+                            continue
+                        if isinstance(result, BaseException):
+                            # For background mode with structured_output, LangChain's
+                            # parser raises ValueError before we can read response_metadata.
+                            # The exception message contains the ID and status, so recover
+                            # the ID via regex rather than silently dropping it.
+                            response_id = _try_extract_id_from_exception(result)
+                        else:
+                            response_id = response_id_extractor(result, row)
                         if response_id:
                             custom_id = row.get(self.column_config.custom_id, '')
                             self._background_response_ids[response_id] = custom_id
@@ -493,6 +567,19 @@ class Batch:
                 column_config=self.column_config,
             )
 
+        # Apply structured output schema if one was saved during run().
+        # Adds a parsed_output column so callers get Pydantic instances directly,
+        # mirroring what with_structured_output() would have returned synchronously.
+        if (rc.return_results
+                and results is not None
+                and not results.empty
+                and self._last_structured_output is not None):
+            schema = self._last_structured_output
+            results = results.copy()
+            results['parsed_output'] = results['openai_response'].apply(
+                lambda r: _parse_from_openai_response(r, schema) if isinstance(r, dict) else None
+            )
+
         if rc.show_progress:
             self._print_end("Retrieval")
 
@@ -531,6 +618,13 @@ class Batch:
         )
         # If run() captured no background IDs (e.g. synchronous LLM), skip retrieve
         if not self._background_response_ids:
+            if self.processing_config.show_progress:
+                print(
+                    "⚠️  No background response IDs captured — retrieval skipped.\n"
+                    "   If you expected background responses, verify:\n"
+                    "   - The model is configured for background mode (e.g. service_tier='flex')\n"
+                    "   - ProcessingConfig(return_exceptions=True) so pending results are returned"
+                )
             return BatchOutcome(batch_results=batch_results, retrieval_results=None)
         retrieval_results = await self.retrieve(
             openai_client=openai_client,

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -517,12 +517,31 @@ class Batch:
                             # run_id as llm_start/llm_end for seamless Parquet joins.
                             run_info = id_capture.response_to_run.get(response_id, {})
                             tags = list((row.get(self.column_config.config) or {}).get('tags', []))
-                            self._background_response_ids[response_id] = {
+                            entry = {
                                 'custom_id': custom_id,
                                 'run_id': run_info.get('run_id', ''),
                                 'parent_run_id': run_info.get('parent_run_id', ''),
                                 'tags': tags,
                             }
+                            self._background_response_ids[response_id] = entry
+                            # Log a queued event so Parquet auto-discovery can find
+                            # this response even if retrieve() is never called.
+                            logger._log_event({
+                                "event_type": "background_retrieval_queued",
+                                "timestamp": datetime.now(timezone.utc).isoformat(),
+                                "execution": {
+                                    "run_id": entry['run_id'] or response_id,
+                                    "parent_run_id": entry['parent_run_id'],
+                                    "custom_id": custom_id,
+                                    "tags": tags,
+                                    "metadata": {}
+                                },
+                                "data": {
+                                    "response_id": response_id,
+                                    "custom_id": custom_id,
+                                },
+                                "raw": {}
+                            })
                     except Exception as exc:
                         warnings.warn(
                             f"response_id_extractor raised {type(exc).__name__} for a row "
@@ -542,6 +561,7 @@ class Batch:
         self,
         openai_client=None,
         retrieval_config: Optional[RetrievalConfig] = None,
+        s3_path: Optional[str] = None,
     ) -> Optional[pd.DataFrame]:
         """
         Retrieve background responses and log them to the same Parquet location.
@@ -553,18 +573,32 @@ class Batch:
         Args:
             openai_client: OpenAI async client. Auto-creates ``AsyncOpenAI()`` if None.
             retrieval_config: Polling and execution settings.
+            s3_path: Optional S3 URI (e.g. ``"s3://bucket/prefix/"``). When provided,
+                pending responses are discovered from that S3 location instead of the
+                batch's own storage. Useful for cross-process resume without a live
+                ``Batch`` object.
 
         Returns:
             DataFrame with columns: response_id, status, openai_response, error
             (or None if retrieval_config.return_results=False).
         """
-        from .background_retrieval import retrieve_background_responses, _query_pending_responses
+        from .background_retrieval import retrieve_background_responses, _query_pending_responses, _parse_s3_uri
         from .storage import LocalStorage, S3Storage
 
         rc = retrieval_config or self.retrieval_config
 
         # Build df from in-memory captured IDs, or auto-discover from storage
-        if self._background_response_ids:
+        if s3_path is not None:
+            # s3_path overrides all other discovery — read pending from S3
+            bucket, prefix = _parse_s3_uri(s3_path)
+            read_storage = S3Storage(S3Config(bucket=bucket, prefix=prefix))
+            df = _query_pending_responses(read_storage)
+            if df.empty:
+                if rc.show_progress:
+                    print("No pending responses found in S3.")
+                return pd.DataFrame() if rc.return_results else None
+            count_desc = f"{len(df)} auto-discovered response(s) from S3"
+        elif self._background_response_ids:
             df = pd.DataFrame([
                 {
                     self.column_config.response_id: rid,

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -26,6 +26,27 @@ class BatchOutcome:
     retrieval_results: Optional[pd.DataFrame]
 
 
+# LLM class names known to support OpenAI's Responses API in background mode
+_OPENAI_BACKGROUND_CLASSES = frozenset({'ChatOpenAI', 'AzureChatOpenAI'})
+# Statuses indicating a response is still in-flight (not yet completed/failed)
+_OPENAI_PENDING_STATUSES = frozenset({'in_progress', 'queued', 'processing'})
+
+
+def _openai_response_id_extractor(result: Any, row: dict) -> Optional[str]:
+    """Extract background response ID from a LangChain OpenAI result.
+
+    Returns the response ID only when ``response_metadata['status']`` is a pending
+    status (background mode). Returns None for synchronous completions so they are
+    not inadvertently queued for retrieval polling.
+    """
+    meta = getattr(result, 'response_metadata', None)
+    if not isinstance(meta, dict):
+        return None
+    if meta.get('status') not in _OPENAI_PENDING_STATUSES:
+        return None
+    return meta.get('id')
+
+
 async def _batch_run(
     df: pd.DataFrame,
     llm: Any,
@@ -223,11 +244,13 @@ class Batch:
         storage_config: Optional[StorageConfig] = None,
         processing_config: Optional[ProcessingConfig] = None,
         column_config: Optional[ColumnConfig] = None,
+        retrieval_config: Optional[RetrievalConfig] = None,
     ):
         self.job_config = job_config or JobConfig()
         self.storage_config = storage_config or StorageConfig()
         self.processing_config = processing_config or ProcessingConfig()
         self.column_config = column_config or ColumnConfig()
+        self.retrieval_config = retrieval_config or RetrievalConfig()
 
         # Resolve storage paths once — shared by run() and retrieve()
         self.local_path, self.resolved_s3_config = _build_storage_paths(
@@ -337,6 +360,10 @@ class Batch:
                 row_timeout=self.processing_config.row_timeout,
             )
 
+        # Auto-detect extractor for known background-capable OpenAI LLM classes
+        if response_id_extractor is None and llm_config.llm_class.__name__ in _OPENAI_BACKGROUND_CLASSES:
+            response_id_extractor = _openai_response_id_extractor
+
         # Capture background response IDs from results
         if response_id_extractor and results:
             self._background_response_ids = {}
@@ -380,7 +407,7 @@ class Batch:
         from .background_retrieval import retrieve_background_responses, _query_pending_responses
         from .storage import LocalStorage, S3Storage
 
-        rc = retrieval_config or RetrievalConfig()
+        rc = retrieval_config or self.retrieval_config
 
         # Build df from in-memory captured IDs, or auto-discover from storage
         if self._background_response_ids:
@@ -459,7 +486,8 @@ class Batch:
             df, llm_config, response_id_extractor=response_id_extractor
         )
         retrieval_results = await self.retrieve(
-            openai_client=openai_client, retrieval_config=retrieval_config
+            openai_client=openai_client,
+            retrieval_config=retrieval_config or self.retrieval_config,
         )
         return BatchOutcome(
             batch_results=batch_results,

--- a/langchain_callback_parquet_logger/batch.py
+++ b/langchain_callback_parquet_logger/batch.py
@@ -17,7 +17,7 @@ from .config import (
     JobConfig, StorageConfig, ProcessingConfig, ColumnConfig,
     S3Config, EventType, LLMConfig, RetrievalConfig
 )
-from .tagging import with_tags
+from .tagging import with_tags, extract_custom_id
 
 
 @dataclass
@@ -78,7 +78,7 @@ def _parse_from_openai_response(response_dict: dict, schema: Type) -> Optional[A
     text: Optional[str] = response_dict.get('output_text')
     if not text:
         for item in response_dict.get('output', []):
-            for content in item.get('content', []):
+            for content in (item.get('content') or []):
                 if content.get('type') == 'output_text':
                     text = content.get('text')
                     break
@@ -464,7 +464,15 @@ class Batch:
                         else:
                             response_id = response_id_extractor(result, row)
                         if response_id:
-                            custom_id = row.get(self.column_config.custom_id, '')
+                            # Try direct column first; fall back to config tags
+                            # (with_tags(custom_id='x') encodes it as 'logger_custom_id:x'
+                            # in the tags list — the same extraction logger.py does for llm_end).
+                            custom_id = (
+                                str(row.get(self.column_config.custom_id) or '')
+                                or extract_custom_id(
+                                    (row.get(self.column_config.config) or {}).get('tags', [])
+                                )
+                            )
                             self._background_response_ids[response_id] = custom_id
                     except Exception as exc:
                         warnings.warn(
@@ -552,6 +560,19 @@ class Batch:
             **(self.job_config.metadata or {}),
         }
 
+        # Build a response_parser callable so that parsing happens *during* retrieval
+        # and parsed_output is included in the background_retrieval_complete Parquet log.
+        # Using a factory function (_make_parser) avoids the closure-captures-variable bug.
+        schema = self._last_structured_output
+        response_parser = None
+        if schema is not None:
+            def _make_parser(s):
+                def parser(response_dict: dict) -> Optional[dict]:
+                    result = _parse_from_openai_response(response_dict, s)
+                    return result.model_dump() if result is not None else None
+                return parser
+            response_parser = _make_parser(schema)
+
         with ParquetLogger(
             log_dir=str(self.local_path),
             buffer_size=1000,
@@ -565,19 +586,20 @@ class Batch:
                 logger=logger,
                 retrieval_config=rc,
                 column_config=self.column_config,
+                response_parser=response_parser,
             )
 
-        # Apply structured output schema if one was saved during run().
-        # Adds a parsed_output column so callers get Pydantic instances directly,
-        # mirroring what with_structured_output() would have returned synchronously.
+        # Convert dict parsed_output → Pydantic objects for caller convenience.
+        # retrieve_background_responses() stores parsed_output as a JSON-serializable dict
+        # (for Parquet logging); convert to a Pydantic instance here for the caller.
         if (rc.return_results
                 and results is not None
                 and not results.empty
-                and self._last_structured_output is not None):
-            schema = self._last_structured_output
+                and schema is not None
+                and 'parsed_output' in results.columns):
             results = results.copy()
-            results['parsed_output'] = results['openai_response'].apply(
-                lambda r: _parse_from_openai_response(r, schema) if isinstance(r, dict) else None
+            results['parsed_output'] = results['parsed_output'].apply(
+                lambda d: schema.model_validate(d) if isinstance(d, dict) else None
             )
 
         if rc.show_progress:

--- a/langchain_callback_parquet_logger/config.py
+++ b/langchain_callback_parquet_logger/config.py
@@ -95,19 +95,25 @@ class ColumnConfig:
 
 @dataclass
 class RetrievalConfig:
-    """Configuration for retrieve_batch_responses() — polling OpenAI background responses.
+    """Configuration for retrieve_background_responses() — polling OpenAI background responses.
 
     Separates polling params (how long to wait for completion) from execution params
     (concurrency, timeouts, logging).
 
+    The ``source`` field controls where the retriever looks for pending responses
+    when auto-discovering from storage (i.e. when no explicit DataFrame is supplied).
+    It only affects the *read* side — new retrieval events are always written to the
+    full configured storage regardless of this setting.
+
     Example:
         config = RetrievalConfig(
+            source="s3",            # discover pending responses from S3
             poll_interval=30.0,     # check every 30 seconds
             max_poll_attempts=40,   # give up after ~20 minutes
             batch_size=50,          # 50 concurrent polls
-            checkpoint_file="./retrieval_checkpoint.parquet",
         )
     """
+    source: Literal["local", "s3"] = "local"  # where to read pending responses from
     poll_interval: float = 30.0       # seconds between status checks when response is pending
     max_poll_attempts: int = 40       # max polls per response before giving up (40 × 30s ≈ 20 min)
     batch_size: int = 50              # number of concurrent requests

--- a/langchain_callback_parquet_logger/config.py
+++ b/langchain_callback_parquet_logger/config.py
@@ -102,8 +102,13 @@ class RetrievalConfig:
     Separates polling params (how long to wait for completion) from execution params
     (concurrency, timeouts, logging).
 
-    The ``source`` field controls where the retriever looks for pending responses
-    when auto-discovering from storage (i.e. when no explicit DataFrame is supplied).
+    The ``source`` field controls where the retriever looks for pending responses:
+
+    - ``"memory"`` (default): only use response IDs captured in-memory during ``run()``;
+      never touches the file system or S3.  Returns empty when no IDs are available.
+    - ``"local"``: auto-discover pending responses from local Parquet files.
+    - ``"s3"``: auto-discover pending responses from S3.
+
     It only affects the *read* side — new retrieval events are always written to the
     full configured storage regardless of this setting.
 
@@ -115,7 +120,7 @@ class RetrievalConfig:
             batch_size=50,          # 50 concurrent polls
         )
     """
-    source: Literal["local", "s3"] = "local"  # where to read pending responses from
+    source: Literal["memory", "local", "s3"] = "memory"  # where to read pending responses from
     poll_interval: float = 30.0       # seconds between status checks when response is pending
     max_poll_attempts: int = 40       # max polls per response before giving up (40 × 30s ≈ 20 min)
     batch_size: int = 50              # number of concurrent requests

--- a/langchain_callback_parquet_logger/config.py
+++ b/langchain_callback_parquet_logger/config.py
@@ -66,7 +66,7 @@ class ProcessingConfig:
     buffer_size: int = 1000
     show_progress: bool = True
     return_exceptions: bool = True
-    return_results: bool = False
+    return_results: bool = True
     event_types: Optional[List[str]] = None
     partition_on: Optional[Union[Literal["date", "event_type"], List[Literal["date", "event_type"]]]] = "date"
     row_timeout: Optional[float] = None  # Per-row timeout in seconds (None = no timeout)

--- a/langchain_callback_parquet_logger/config.py
+++ b/langchain_callback_parquet_logger/config.py
@@ -68,7 +68,7 @@ class ProcessingConfig:
     return_exceptions: bool = True
     return_results: bool = False
     event_types: Optional[List[str]] = None
-    partition_on: Optional[Literal["date"]] = "date"
+    partition_on: Optional[Union[Literal["date", "event_type"], List[Literal["date", "event_type"]]]] = "date"
     row_timeout: Optional[float] = None  # Per-row timeout in seconds (None = no timeout)
 
     def __post_init__(self):
@@ -91,6 +91,8 @@ class ColumnConfig:
     prompt: str = "prompt"
     config: str = "config"
     tools: Optional[str] = "tools"
+    response_id: str = "response_id"
+    custom_id: str = "custom_id"
 
 
 @dataclass

--- a/langchain_callback_parquet_logger/logger.py
+++ b/langchain_callback_parquet_logger/logger.py
@@ -116,69 +116,48 @@ class ParquetLogger(BaseCallbackHandler):
         except ImportError:
             return False
 
-    def _serialize_any(self, obj: Any) -> Any:
-        """Try all possible serialization methods for complete data capture."""
+    @staticmethod
+    def _serialize_obj(obj: Any) -> Any:
+        """Try model_dump → to_dict → __dict__ in order. Returns obj unchanged if all fail."""
         try:
-            # Special handling for LLMResult to preserve nested AIMessage metadata
-            if obj.__class__.__name__ == 'LLMResult':
-                # First get the standard serialization
-                if hasattr(obj, 'model_dump'):
-                    result = obj.model_dump(mode='json', by_alias=False)
-                elif hasattr(obj, 'to_dict'):
-                    result = obj.to_dict()
-                elif hasattr(obj, '__dict__'):
-                    result = {k: v for k, v in obj.__dict__.items() if not k.startswith('_')}
-                else:
-                    result = obj
-
-                # Fix nested message serialization to preserve all metadata
-                if 'generations' in result and hasattr(obj, 'generations'):
-                    for i, gen_list in enumerate(obj.generations):
-                        for j, gen in enumerate(gen_list):
-                            if hasattr(gen, 'message'):
-                                # Directly serialize the message to preserve all fields
-                                msg = gen.message
-                                if hasattr(msg, 'model_dump'):
-                                    result['generations'][i][j]['message'] = msg.model_dump(mode='json', by_alias=False)
-                                elif hasattr(msg, 'to_dict'):
-                                    result['generations'][i][j]['message'] = msg.to_dict()
-                                elif hasattr(msg, '__dict__'):
-                                    result['generations'][i][j]['message'] = {
-                                        k: v for k, v in msg.__dict__.items() if not k.startswith('_')
-                                    }
-                return result
-
-            # Try various serialization methods in order of preference
-            if hasattr(obj, 'model_dump'):  # Pydantic v2
+            if hasattr(obj, 'model_dump'):
                 result = obj.model_dump(mode='json', by_alias=False)
                 if isinstance(result, (dict, list, str, int, float, bool, type(None))):
                     return result
             elif hasattr(obj, 'to_dict'):
                 return obj.to_dict()
             elif hasattr(obj, '__dict__'):
-                # Get object attributes (skip private ones)
                 return {k: v for k, v in obj.__dict__.items() if not k.startswith('_')}
-            else:
-                # Return as-is, let _safe_json_dumps handle edge cases
-                return obj
         except Exception:
-            # If all else fails, return as-is
+            pass
+        return obj
+
+    def _serialize_any(self, obj: Any) -> Any:
+        """Try all possible serialization methods for complete data capture."""
+        try:
+            # Special handling for LLMResult to preserve nested AIMessage metadata
+            if obj.__class__.__name__ == 'LLMResult':
+                result = self._serialize_obj(obj)
+
+                # Fix nested message serialization to preserve all fields
+                if isinstance(result, dict) and 'generations' in result and hasattr(obj, 'generations'):
+                    for i, gen_list in enumerate(obj.generations):
+                        for j, gen in enumerate(gen_list):
+                            if hasattr(gen, 'message'):
+                                result['generations'][i][j]['message'] = self._serialize_obj(gen.message)
+                return result
+
+            return self._serialize_obj(obj)
+        except Exception:
             return obj
 
     def _safe_json_dumps(self, obj: Any) -> str:
         """Convert object to JSON string safely."""
         def default(o):
-            # Defensive handling for Pydantic models that weren't pre-serialized
-            if hasattr(o, 'model_dump'):
-                try:
-                    result = o.model_dump(mode='json', by_alias=False)
-                    if isinstance(result, (dict, list, str, int, float, bool, type(None))):
-                        return result
-                except Exception:
-                    pass  # Fall through to string conversion
-            if hasattr(o, '__str__'):
-                return str(o)
-            return f"<{type(o).__name__}>"
+            result = self._serialize_obj(o)
+            if result is not o:
+                return result
+            return str(o)
         return json.dumps(obj, default=default)
 
     def _create_standard_payload(self, event_type: str, **kwargs) -> Dict[str, Any]:
@@ -264,6 +243,15 @@ class ParquetLogger(BaseCallbackHandler):
         # Raw already has kwargs from _create_standard_payload
         self._log_event(payload)
 
+    def _handle_error_event(self, event_type: str, error: Exception, **kwargs) -> None:
+        """Generic error event handler shared by on_llm_error, on_chain_error, on_tool_error."""
+        if event_type not in self.event_types:
+            return
+        payload = self._create_standard_payload(event_type, **kwargs)
+        self._add_error_info(payload, error)
+        payload["raw"]["error"] = self._serialize_any(error)
+        self._log_event(payload)
+
     # Event handlers
     def on_llm_start(self, serialized: Dict, prompts: List[str], **kwargs):
         """Log LLM start event."""
@@ -324,14 +312,7 @@ class ParquetLogger(BaseCallbackHandler):
 
     def on_llm_error(self, error, **kwargs):
         """Log LLM error event."""
-        if 'llm_error' not in self.event_types:
-            return
-
-        payload = self._create_standard_payload('llm_error', **kwargs)
-        self._add_error_info(payload, error)
-        # Capture complete error in raw
-        payload["raw"]["error"] = self._serialize_any(error)
-        self._log_event(payload)
+        self._handle_error_event('llm_error', error, **kwargs)
 
     def on_chain_start(self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs):
         """Log chain start event."""
@@ -356,14 +337,7 @@ class ParquetLogger(BaseCallbackHandler):
 
     def on_chain_error(self, error: Exception, **kwargs):
         """Log chain error event."""
-        if 'chain_error' not in self.event_types:
-            return
-
-        payload = self._create_standard_payload('chain_error', **kwargs)
-        self._add_error_info(payload, error)
-        # Capture complete error in raw
-        payload["raw"]["error"] = self._serialize_any(error)
-        self._log_event(payload)
+        self._handle_error_event('chain_error', error, **kwargs)
 
     def on_tool_start(self, serialized: Dict[str, Any], input_str: str, **kwargs):
         """Log tool start event."""
@@ -390,14 +364,7 @@ class ParquetLogger(BaseCallbackHandler):
 
     def on_tool_error(self, error: Exception, **kwargs):
         """Log tool error event."""
-        if 'tool_error' not in self.event_types:
-            return
-
-        payload = self._create_standard_payload('tool_error', **kwargs)
-        self._add_error_info(payload, error)
-        # Capture complete error in raw
-        payload["raw"]["error"] = self._serialize_any(error)
-        self._log_event(payload)
+        self._handle_error_event('tool_error', error, **kwargs)
 
     def on_agent_action(self, action, **kwargs):
         """Log agent action event."""
@@ -523,12 +490,7 @@ class ParquetLogger(BaseCallbackHandler):
                         parts.append(f"date={date.today()}")
                     elif p == "event_type":
                         parts.append(f"event_type={entry.get('event_type', 'unknown')}")
-                if not parts:
-                    return None
-                result = Path(parts[0])
-                for part in parts[1:]:
-                    result = result / part
-                return result
+                return Path(*parts) if parts else None
 
             # Group entries by their partition directory (preserves insertion order)
             groups: Dict[str, list] = {}

--- a/langchain_callback_parquet_logger/logger.py
+++ b/langchain_callback_parquet_logger/logger.py
@@ -477,44 +477,42 @@ class ParquetLogger(BaseCallbackHandler):
         )
 
     def _write_buffer(self, buffer: list) -> None:
-        """Write buffer to Parquet file(s) (called without lock held)."""
+        """Write buffer to Parquet file(s) (called without lock held).
+
+        Any exception raised here propagates to _writer_loop, which stores it in
+        _writer_errors so it surfaces at the next flush() call.  This covers both
+        S3 errors (RuntimeError from S3Storage with on_failure='error') and local
+        write failures (OSError, PermissionError, disk-full, etc.).
+        """
         if not buffer:
             return
-        try:
-            partitions = self._normalize_partitions()
 
-            def get_partition_dir(entry: dict) -> Optional[Path]:
-                parts = []
-                for p in partitions:
-                    if p == "date":
-                        parts.append(f"date={date.today()}")
-                    elif p == "event_type":
-                        parts.append(f"event_type={entry.get('event_type', 'unknown')}")
-                return Path(*parts) if parts else None
+        partitions = self._normalize_partitions()
 
-            # Group entries by their partition directory (preserves insertion order)
-            groups: Dict[str, list] = {}
-            for entry in buffer:
-                partition_dir = get_partition_dir(entry)
-                key = str(partition_dir) if partition_dir is not None else ""
-                if key not in groups:
-                    groups[key] = []
-                groups[key].append(entry)
+        def get_partition_dir(entry: dict) -> Optional[Path]:
+            parts = []
+            for p in partitions:
+                if p == "date":
+                    parts.append(f"date={date.today()}")
+                elif p == "event_type":
+                    parts.append(f"event_type={entry.get('event_type', 'unknown')}")
+            return Path(*parts) if parts else None
 
-            timestamp_str = datetime.now().strftime("%H%M%S_%f")
-            for path_key, entries in groups.items():
-                filename = f"logs_{timestamp_str}.parquet"
-                relative_path = (Path(path_key) / filename) if path_key else Path(filename)
-                table = self._build_table(entries)
-                self.storage.write(table, relative_path)
+        # Group entries by their partition directory (preserves insertion order)
+        groups: Dict[str, list] = {}
+        for entry in buffer:
+            partition_dir = get_partition_dir(entry)
+            key = str(partition_dir) if partition_dir is not None else ""
+            if key not in groups:
+                groups[key] = []
+            groups[key].append(entry)
 
-        except RuntimeError:
-            # Re-raise storage errors
-            raise
-        except Exception as e:
-            import traceback
-            print(f"Failed to write logs: {e}")
-            print(f"Full traceback:\n{traceback.format_exc()}")
+        timestamp_str = datetime.now().strftime("%H%M%S_%f")
+        for path_key, entries in groups.items():
+            filename = f"logs_{timestamp_str}.parquet"
+            relative_path = (Path(path_key) / filename) if path_key else Path(filename)
+            table = self._build_table(entries)
+            self.storage.write(table, relative_path)
 
     # Context manager support
     def __enter__(self):

--- a/langchain_callback_parquet_logger/storage.py
+++ b/langchain_callback_parquet_logger/storage.py
@@ -1,6 +1,7 @@
 """Storage backends for Parquet files."""
 
 import time
+import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, Optional
@@ -132,7 +133,7 @@ class S3Storage(StorageBackend):
         try:
             self.client.head_object(Bucket=self.config.bucket, Key=s3_key)
             return True
-        except:
+        except Exception:
             return False
 
     def list_files(self) -> List[str]:
@@ -182,8 +183,11 @@ class CompositeStorage(StorageBackend):
                     if f not in seen:
                         seen.add(f)
                         result.append(f)
-            except Exception:
-                pass
+            except Exception as e:
+                warnings.warn(
+                    f"Failed to list files from a storage backend "
+                    f"({type(backend).__name__}): {e}"
+                )
         return result
 
     def read_table(self, filepath: Path) -> pa.Table:

--- a/langchain_callback_parquet_logger/storage.py
+++ b/langchain_callback_parquet_logger/storage.py
@@ -25,6 +25,16 @@ class StorageBackend(ABC):
         """Check if file exists in storage."""
         pass
 
+    @abstractmethod
+    def list_files(self) -> List[str]:
+        """Return list of relative parquet file paths under this storage root."""
+        pass
+
+    @abstractmethod
+    def read_table(self, filepath: Path) -> pa.Table:
+        """Read a parquet file and return as a PyArrow table."""
+        pass
+
 
 class LocalStorage(StorageBackend):
     """Local filesystem storage backend."""
@@ -43,6 +53,17 @@ class LocalStorage(StorageBackend):
     def exists(self, filepath: Path) -> bool:
         """Check if file exists locally."""
         return (self.base_dir / filepath).exists()
+
+    def list_files(self) -> List[str]:
+        """List all parquet files under base_dir, returning relative paths."""
+        return [
+            str(p.relative_to(self.base_dir))
+            for p in self.base_dir.rglob("*.parquet")
+        ]
+
+    def read_table(self, filepath: Path) -> pa.Table:
+        """Read a parquet file from local filesystem."""
+        return pq.read_table(self.base_dir / filepath)
 
 
 class S3Storage(StorageBackend):
@@ -114,6 +135,26 @@ class S3Storage(StorageBackend):
         except:
             return False
 
+    def list_files(self) -> List[str]:
+        """List all parquet files under the S3 prefix, returning relative paths."""
+        paginator = self.client.get_paginator('list_objects_v2')
+        files = []
+        for page in paginator.paginate(Bucket=self.config.bucket, Prefix=self.config.prefix):
+            for obj in page.get('Contents', []):
+                key = obj['Key']
+                if key.endswith('.parquet'):
+                    relative = key[len(self.config.prefix):]
+                    if relative:
+                        files.append(relative)
+        return files
+
+    def read_table(self, filepath: Path) -> pa.Table:
+        """Read a parquet file from S3."""
+        s3_key = f"{self.config.prefix}{filepath}"
+        response = self.client.get_object(Bucket=self.config.bucket, Key=s3_key)
+        data = response['Body'].read()
+        return pq.read_table(pa.BufferReader(data))
+
 
 class CompositeStorage(StorageBackend):
     """Composite storage that writes to multiple backends."""
@@ -130,6 +171,30 @@ class CompositeStorage(StorageBackend):
     def exists(self, filepath: Path) -> bool:
         """Check if file exists in any backend."""
         return any(backend.exists(filepath) for backend in self.backends)
+
+    def list_files(self) -> List[str]:
+        """List files from all backends, deduplicated (preserving first-seen order)."""
+        seen: set = set()
+        result = []
+        for backend in self.backends:
+            try:
+                for f in backend.list_files():
+                    if f not in seen:
+                        seen.add(f)
+                        result.append(f)
+            except Exception:
+                pass
+        return result
+
+    def read_table(self, filepath: Path) -> pa.Table:
+        """Read from the first backend that successfully returns the file."""
+        last_error: Optional[Exception] = None
+        for backend in self.backends:
+            try:
+                return backend.read_table(filepath)
+            except Exception as e:
+                last_error = e
+        raise last_error or FileNotFoundError(f"File not found in any backend: {filepath}")
 
 
 def create_storage(log_dir: str, s3_config: Optional[S3Config] = None) -> StorageBackend:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.3.0a6"
+version = "3.3.0a7"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.3.0a3"
+version = "3.3.0a4"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.3.0a7"
+version = "4.0.0"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.3.0"
+version = "3.3.0a1"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.2.1"
+version = "3.3.0"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -43,7 +43,6 @@ test = [
 background = [
     "openai>=1.0.0",
     "pandas>=1.3.0",
-    "tqdm>=4.60.0",
 ]
 s3 = [
     "boto3>=1.26.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.3.0a1"
+version = "3.3.0a2"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.3.0a2"
+version = "3.3.0a3"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.3.0a5"
+version = "3.3.0a6"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-callback-parquet-logger"
-version = "3.3.0a4"
+version = "3.3.0a5"
 description = "A Parquet-based callback handler for logging LangChain LLM interactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_background_retrieval.py
+++ b/tests/test_background_retrieval.py
@@ -22,7 +22,7 @@ from langchain_callback_parquet_logger.background_retrieval import (
     _BACKGROUND_EVENT_TYPES,
     _TERMINAL_RETRIEVAL_EVENT_TYPES,
 )
-from langchain_callback_parquet_logger.config import StorageConfig, JobConfig
+from langchain_callback_parquet_logger.config import StorageConfig, JobConfig, RetrievalConfig
 from langchain_callback_parquet_logger.storage import LocalStorage
 from langchain_callback_parquet_logger.logger import SCHEMA
 
@@ -41,7 +41,7 @@ def sample_df():
 def mock_openai_client():
     """Create a mock OpenAI client."""
     client = AsyncMock()
-    
+
     # Mock successful response
     mock_response = MagicMock()
     mock_response.model_dump.return_value = {
@@ -52,7 +52,7 @@ def mock_openai_client():
         'choices': [{'message': {'content': 'Test response'}}],
         'usage': {'total_tokens': 100}
     }
-    
+
     client.responses.retrieve = AsyncMock(return_value=mock_response)
     return client
 
@@ -62,14 +62,14 @@ async def test_basic_retrieval(sample_df, mock_openai_client):
     """Test basic retrieval functionality."""
     with tempfile.TemporaryDirectory() as tmpdir:
         logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
-        
+
         results = await retrieve_background_responses(
             sample_df,
             mock_openai_client,
             logger=logger,
-            show_progress=False
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
-        
+
         # Check results DataFrame
         assert results is not None
         assert len(results) == 3
@@ -77,10 +77,10 @@ async def test_basic_retrieval(sample_df, mock_openai_client):
         assert 'status' in results.columns
         assert 'openai_response' in results.columns
         assert all(results['status'] == 'completed')
-        
+
         # Verify API was called for each response
         assert mock_openai_client.responses.retrieve.call_count == 3
-        
+
         # Check logs were created
         logger.flush()
         log_files = list(Path(tmpdir).rglob('*.parquet'))
@@ -92,14 +92,14 @@ async def test_rate_limiting():
     """Test rate limiting with 429 errors."""
     import sys
     from unittest.mock import patch
-    
+
     df = pd.DataFrame({
         'response_id': ['resp_001'],
         'custom_id': ['user-001']
     })
-    
+
     client = AsyncMock()
-    
+
     # Test with proper openai.RateLimitError if available
     try:
         import openai
@@ -114,7 +114,7 @@ async def test_rate_limiting():
                 response=mock_response,
                 body={"error": {"message": "Rate limit exceeded"}}
             )
-            
+
             # Simulate rate limit error on first call, then success
             client.responses.retrieve = AsyncMock(
                 side_effect=[
@@ -122,23 +122,22 @@ async def test_rate_limiting():
                     MagicMock(model_dump=lambda **kwargs: {'id': 'resp_001', 'status': 'completed'})
                 ]
             )
-            
+
             with patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
                 results = await retrieve_background_responses(
                     df,
                     client,
-                    max_retries=3,
-                    show_progress=False
+                    retrieval_config=RetrievalConfig(max_retries=3, show_progress=False),
                 )
-                
+
                 # Sleep should be called for RateLimitError
                 mock_sleep.assert_called()
                 assert results.iloc[0]['status'] == 'completed'
-                
+
     except (ImportError, AttributeError, TypeError):
         # If openai is not available, test with generic exception
         rate_limit_error = Exception("Server error")
-        
+
         # Simulate error on first call, then success
         client.responses.retrieve = AsyncMock(
             side_effect=[
@@ -146,14 +145,13 @@ async def test_rate_limiting():
                 MagicMock(model_dump=lambda **kwargs: {'id': 'resp_001', 'status': 'completed'})
             ]
         )
-        
+
         results = await retrieve_background_responses(
             df,
             client,
-            max_retries=3,
-            show_progress=False
+            retrieval_config=RetrievalConfig(max_retries=3, show_progress=False),
         )
-        
+
         # The generic exception won't be retried, so it should fail
         assert results.iloc[0]['status'] == 'failed'
 
@@ -163,27 +161,26 @@ async def test_checkpoint_resume(sample_df):
     """Test checkpoint save and resume functionality."""
     with tempfile.TemporaryDirectory() as tmpdir:
         checkpoint_file = f"{tmpdir}/checkpoint.parquet"
-        
+
         # Create a checkpoint with one processed ID
         save_checkpoint(checkpoint_file, [
             {'response_id': 'resp_001', 'processed': True, 'error': None}
         ])
-        
+
         client = AsyncMock()
         mock_response = MagicMock(model_dump=lambda **kwargs: {'id': 'resp', 'status': 'completed'})
         client.responses.retrieve = AsyncMock(return_value=mock_response)
-        
+
         # Run retrieval with checkpoint
         results = await retrieve_background_responses(
             sample_df,
             client,
-            checkpoint_file=checkpoint_file,
-            show_progress=False
+            retrieval_config=RetrievalConfig(checkpoint_file=checkpoint_file, show_progress=False),
         )
-        
+
         # Should only retrieve 2 responses (resp_002 and resp_003)
         assert client.responses.retrieve.call_count == 2
-        
+
         # First response should be marked as already processed
         resp_001_result = results[results['response_id'] == 'resp_001'].iloc[0]
         assert resp_001_result['status'] == 'already_processed'
@@ -194,23 +191,22 @@ async def test_memory_efficient_mode(sample_df, mock_openai_client):
     """Test return_results=False for memory efficiency."""
     with tempfile.TemporaryDirectory() as tmpdir:
         logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
-        
+
         results = await retrieve_background_responses(
             sample_df,
             mock_openai_client,
             logger=logger,
-            return_results=False,  # Don't keep results in memory
-            show_progress=False
+            retrieval_config=RetrievalConfig(return_results=False, show_progress=False),
         )
-        
+
         # Should return None
         assert results is None
-        
+
         # But logs should still be written
         logger.flush()
         log_files = list(Path(tmpdir).rglob('*.parquet'))
         assert len(log_files) > 0
-        
+
         # Verify all responses were retrieved
         assert mock_openai_client.responses.retrieve.call_count == 3
 
@@ -222,7 +218,7 @@ async def test_partial_failures(mock_openai_client):
         'response_id': ['resp_001', 'resp_002', 'resp_003'],
         'custom_id': ['user-001', 'user-002', 'user-003']
     })
-    
+
     # Mock mixed success/failure responses
     mock_openai_client.responses.retrieve = AsyncMock(
         side_effect=[
@@ -231,14 +227,13 @@ async def test_partial_failures(mock_openai_client):
             MagicMock(model_dump=lambda **kwargs: {'id': 'resp_003', 'status': 'completed'})
         ]
     )
-    
+
     results = await retrieve_background_responses(
         df,
         mock_openai_client,
-        max_retries=1,
-        show_progress=False
+        retrieval_config=RetrievalConfig(max_retries=1, show_progress=False),
     )
-    
+
     # Check mixed statuses
     assert len(results) == 3
     assert results.iloc[0]['status'] == 'completed'
@@ -254,31 +249,31 @@ async def test_missing_columns():
     df = pd.DataFrame({
         'response_id': ['resp_001']
     })
-    
+
     client = AsyncMock()
     client.responses.retrieve = AsyncMock(
         return_value=MagicMock(model_dump=lambda **kwargs: {'id': 'resp_001'})
     )
-    
+
     # Should work with warning
     with pytest.warns(UserWarning, match="custom_id"):
         results = await retrieve_background_responses(
             df,
             client,
-            show_progress=False
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
-    
+
     assert results is not None
     assert len(results) == 1
-    
+
     # Missing response_id column should raise error
     df_bad = pd.DataFrame({'other_column': ['data']})
-    
+
     with pytest.raises(ValueError, match="response_id"):
         await retrieve_background_responses(
             df_bad,
             client,
-            show_progress=False
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
 
 
@@ -289,23 +284,21 @@ async def test_timeout_handling():
         'response_id': ['resp_001'],
         'custom_id': ['user-001']
     })
-    
+
     client = AsyncMock()
-    
+
     # Create a coroutine that never completes (needs to accept response_id parameter)
     async def never_complete(response_id):
         await asyncio.sleep(100)
-    
+
     client.responses.retrieve = AsyncMock(side_effect=never_complete)
-    
+
     results = await retrieve_background_responses(
         df,
         client,
-        timeout=0.1,  # Very short timeout
-        max_retries=1,
-        show_progress=False
+        retrieval_config=RetrievalConfig(timeout=0.1, max_retries=1, show_progress=False),
     )
-    
+
     # Should fail with timeout
     assert results.iloc[0]['status'] == 'failed'
     assert 'Timeout' in results.iloc[0]['error']
@@ -319,23 +312,22 @@ async def test_batch_processing():
         'response_id': [f'resp_{i:03d}' for i in range(10)],
         'custom_id': [f'user_{i:03d}' for i in range(10)]
     })
-    
+
     client = AsyncMock()
     call_times = []
-    
+
     async def track_calls(response_id):
         call_times.append(asyncio.get_event_loop().time())
         return MagicMock(model_dump=lambda **kwargs: {'id': response_id})
-    
+
     client.responses.retrieve = AsyncMock(side_effect=track_calls)
-    
+
     await retrieve_background_responses(
         df,
         client,
-        batch_size=3,  # Process 3 at a time
-        show_progress=False
+        retrieval_config=RetrievalConfig(batch_size=3, show_progress=False),
     )
-    
+
     # All should be retrieved
     assert client.responses.retrieve.call_count == 10
 
@@ -347,26 +339,26 @@ async def test_logging_event_types():
         'response_id': ['resp_001'],
         'custom_id': ['user-001']
     })
-    
+
     with tempfile.TemporaryDirectory() as tmpdir:
         logger = ParquetLogger(log_dir=tmpdir, buffer_size=1)
-        
+
         client = AsyncMock()
         client.responses.retrieve = AsyncMock(
             return_value=MagicMock(model_dump=lambda **kwargs: {'id': 'resp_001'})
         )
-        
+
         await retrieve_background_responses(
             df,
             client,
             logger=logger,
-            show_progress=False
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
-        
+
         # Read logs and check event types
         log_df = pd.read_parquet(tmpdir)
         event_types = log_df['event_type'].unique()
-        
+
         assert 'background_retrieval_attempt' in event_types
         assert 'background_retrieval_complete' in event_types
 
@@ -391,7 +383,7 @@ async def test_schema_consistency():
             df,
             client,
             logger=logger,
-            show_progress=False
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
 
         log_df = pd.read_parquet(tmpdir)
@@ -427,7 +419,6 @@ async def test_auto_discovery_from_storage():
         #   resp_pending  → latest event is background_retrieval_attempt (non-terminal)
         #   resp_done     → latest event is background_retrieval_complete (terminal)
         logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
-        from datetime import timezone
 
         # Pending response: only an attempt event logged
         logger._add_entry({
@@ -488,12 +479,11 @@ async def test_auto_discovery_from_storage():
         )
 
         # Use path_template="" so the resolved path is exactly tmpdir
-        # (mirroring how batch_process + retrieve would share the same resolved path)
         storage_config = StorageConfig(output_dir=tmpdir, path_template="")
         results = await retrieve_background_responses(
             storage_config=storage_config,
             openai_client=client,
-            show_progress=False,
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
 
         # Only the pending response should have been retrieved
@@ -512,7 +502,6 @@ async def test_auto_discovery_no_pending():
     """When all responses are terminal, auto-discovery returns empty without API calls."""
     with tempfile.TemporaryDirectory() as tmpdir:
         logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
-        from datetime import timezone
 
         # Write a completed response
         logger._add_entry({
@@ -539,7 +528,7 @@ async def test_auto_discovery_no_pending():
         results = await retrieve_background_responses(
             storage_config=storage_config,
             openai_client=client,
-            show_progress=False,
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
 
         # No API calls should be made
@@ -559,7 +548,7 @@ async def test_auto_discovery_empty_storage():
         results = await retrieve_background_responses(
             storage_config=storage_config,
             openai_client=client,
-            show_progress=False,
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
 
         assert client.responses.retrieve.call_count == 0
@@ -575,7 +564,7 @@ async def test_auto_discovery_requires_storage_config():
     with pytest.raises(ValueError, match="storage_config"):
         await retrieve_background_responses(
             openai_client=client,
-            show_progress=False,
+            retrieval_config=RetrievalConfig(show_progress=False),
         )
 
 
@@ -583,10 +572,7 @@ async def test_auto_discovery_requires_storage_config():
 async def test_source_local_uses_only_local_storage():
     """source='local' should read only from LocalStorage, not S3."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        from langchain_callback_parquet_logger.config import RetrievalConfig, S3Config
-
         logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
-        from datetime import timezone
 
         logger._add_entry({
             'timestamp': datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
@@ -613,13 +599,12 @@ async def test_source_local_uses_only_local_storage():
         )
 
         # source="local" (default) — should find the entry written locally
-        rc = RetrievalConfig(source="local")
+        rc = RetrievalConfig(source="local", show_progress=False)
         storage_config = StorageConfig(output_dir=tmpdir, path_template="")
         results = await retrieve_background_responses(
             storage_config=storage_config,
             retrieval_config=rc,
             openai_client=client,
-            show_progress=False,
         )
 
         assert client.responses.retrieve.call_count == 1
@@ -630,8 +615,6 @@ async def test_source_local_uses_only_local_storage():
 @pytest.mark.asyncio
 async def test_source_s3_requires_s3_config():
     """source='s3' without an s3_config should raise ValueError."""
-    from langchain_callback_parquet_logger.config import RetrievalConfig
-
     client = AsyncMock()
     # StorageConfig with no s3_config
     storage_config = StorageConfig(output_dir="/tmp/test", path_template="")
@@ -639,9 +622,8 @@ async def test_source_s3_requires_s3_config():
     with pytest.raises(ValueError, match="s3_config"):
         await retrieve_background_responses(
             storage_config=storage_config,
-            retrieval_config=RetrievalConfig(source="s3"),
+            retrieval_config=RetrievalConfig(source="s3", show_progress=False),
             openai_client=client,
-            show_progress=False,
         )
 
 

--- a/tests/test_background_retrieval.py
+++ b/tests/test_background_retrieval.py
@@ -19,10 +19,11 @@ from langchain_callback_parquet_logger.background_retrieval import (
     retrieve_background_responses,
     save_checkpoint,
     _query_pending_responses,
+    _parse_s3_uri,
     _BACKGROUND_EVENT_TYPES,
     _TERMINAL_RETRIEVAL_EVENT_TYPES,
 )
-from langchain_callback_parquet_logger.config import StorageConfig, JobConfig, RetrievalConfig
+from langchain_callback_parquet_logger.config import StorageConfig, JobConfig, RetrievalConfig, S3Config
 from langchain_callback_parquet_logger.storage import LocalStorage
 from langchain_callback_parquet_logger.logger import SCHEMA
 
@@ -625,6 +626,149 @@ async def test_source_s3_requires_s3_config():
             retrieval_config=RetrievalConfig(source="s3", show_progress=False),
             openai_client=client,
         )
+
+
+# --- _parse_s3_uri tests ---
+
+def test_parse_s3_uri_basic():
+    """Standard S3 URI with trailing slash."""
+    assert _parse_s3_uri("s3://my-bucket/path/to/logs/") == ("my-bucket", "path/to/logs/")
+
+
+def test_parse_s3_uri_no_trailing_slash():
+    """S3 URI without trailing slash."""
+    assert _parse_s3_uri("s3://my-bucket/path/to/logs") == ("my-bucket", "path/to/logs")
+
+
+def test_parse_s3_uri_root_bucket():
+    """S3 URI with bucket only (no prefix)."""
+    assert _parse_s3_uri("s3://my-bucket") == ("my-bucket", "")
+
+
+def test_parse_s3_uri_invalid():
+    """Non-s3:// URI raises ValueError."""
+    with pytest.raises(ValueError, match="s3://"):
+        _parse_s3_uri("https://bucket/prefix/")
+
+
+# --- _query_pending_responses enriched return tests ---
+
+def test_query_pending_responses_returns_enriched_columns():
+    """_query_pending_responses() returns run_id, parent_run_id, tags alongside response_id."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
+
+        logger._add_entry({
+            'timestamp': datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            'run_id': 'lc-uuid-001',
+            'parent_run_id': 'lc-parent-001',
+            'custom_id': 'cid-enriched',
+            'event_type': 'background_retrieval_queued',
+            'logger_metadata': '{}',
+            'payload': json.dumps({
+                'event_type': 'background_retrieval_queued',
+                'timestamp': '2026-01-01T00:00:00+00:00',
+                'execution': {
+                    'run_id': 'lc-uuid-001',
+                    'parent_run_id': 'lc-parent-001',
+                    'custom_id': 'cid-enriched',
+                    'tags': ['tag1', 'logger_custom_id:cid-enriched'],
+                    'metadata': {}
+                },
+                'data': {'response_id': 'resp_enrich_001', 'custom_id': 'cid-enriched'},
+                'raw': {}
+            })
+        })
+        logger.flush()
+
+        storage = LocalStorage(tmpdir)
+        result = _query_pending_responses(storage)
+
+        assert not result.empty
+        assert 'run_id' in result.columns
+        assert 'parent_run_id' in result.columns
+        assert 'tags' in result.columns
+
+        row = result.iloc[0]
+        assert row['response_id'] == 'resp_enrich_001'
+        assert row['run_id'] == 'lc-uuid-001'
+        assert row['parent_run_id'] == 'lc-parent-001'
+        assert 'tag1' in row['tags']
+
+
+def test_query_pending_responses_no_compat_fallback():
+    """Events with no data.response_id in payload are excluded (no fallback to run_id column)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Write a background event whose payload has no data.response_id
+        table = pa.table({
+            'timestamp': pa.array([1000000000000], type=pa.int64()),
+            'run_id': ['resp_old_format'],
+            'parent_run_id': [''],
+            'custom_id': ['cid-old'],
+            'event_type': ['background_retrieval_attempt'],
+            'logger_metadata': ['{}'],
+            'payload': [json.dumps({
+                'event_type': 'background_retrieval_attempt',
+                'data': {},  # No response_id — simulates malformed/old event
+                'execution': {'run_id': 'resp_old_format', 'custom_id': 'cid-old'},
+            })],
+        })
+        pq.write_table(table, f'{tmpdir}/test.parquet')
+
+        storage = LocalStorage(tmpdir)
+        result = _query_pending_responses(storage)
+
+        # Should be excluded — no fallback to run_id column
+        assert result.empty
+
+
+@pytest.mark.asyncio
+async def test_retrieve_background_responses_s3_path_auto_discovers():
+    """s3_path causes S3Storage to be used for auto-discovery."""
+    from unittest.mock import patch
+
+    pending_df = pd.DataFrame({
+        'response_id': ['resp_s3_001'],
+        'custom_id': ['cid_s3_001'],
+        'run_id': ['lc-uuid-s3'],
+        'parent_run_id': [''],
+        'tags': [[]],
+    })
+
+    with patch(
+        'langchain_callback_parquet_logger.background_retrieval._query_pending_responses',
+        return_value=pending_df
+    ) as mock_query, patch(
+        'langchain_callback_parquet_logger.background_retrieval.S3Storage'
+    ) as MockS3Storage:
+        client = AsyncMock()
+        client.responses.retrieve = AsyncMock(
+            return_value=MagicMock(model_dump=lambda **kwargs: {'id': 'resp_s3_001', 'status': 'completed'})
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with ParquetLogger(log_dir=tmpdir, buffer_size=1) as logger:
+                results = await retrieve_background_responses(
+                    s3_path="s3://test-bucket/my/prefix/",
+                    openai_client=client,
+                    logger=logger,
+                    retrieval_config=RetrievalConfig(show_progress=False),
+                )
+
+    # S3Storage was instantiated with S3Config(bucket='test-bucket', prefix='my/prefix/')
+    MockS3Storage.assert_called_once()
+    s3_cfg_arg = MockS3Storage.call_args[0][0]
+    assert isinstance(s3_cfg_arg, S3Config)
+    assert s3_cfg_arg.bucket == 'test-bucket'
+    assert s3_cfg_arg.prefix == 'my/prefix/'
+
+    # _query_pending_responses was called with the S3Storage instance
+    mock_query.assert_called_once_with(MockS3Storage.return_value)
+
+    assert results is not None
+    assert len(results) == 1
+    assert results.iloc[0]['response_id'] == 'resp_s3_001'
+    assert results.iloc[0]['status'] == 'completed'
 
 
 if __name__ == "__main__":

--- a/tests/test_background_retrieval.py
+++ b/tests/test_background_retrieval.py
@@ -11,11 +11,20 @@ import tempfile
 import pytest
 import pandas as pd
 
+import pyarrow as pa
+import pyarrow.parquet as pq
+
 from langchain_callback_parquet_logger import ParquetLogger
 from langchain_callback_parquet_logger.background_retrieval import (
     retrieve_background_responses,
-    save_checkpoint
+    save_checkpoint,
+    _query_pending_responses,
+    _BACKGROUND_EVENT_TYPES,
+    _TERMINAL_RETRIEVAL_EVENT_TYPES,
 )
+from langchain_callback_parquet_logger.config import StorageConfig, JobConfig
+from langchain_callback_parquet_logger.storage import LocalStorage
+from langchain_callback_parquet_logger.logger import SCHEMA
 
 
 @pytest.fixture
@@ -360,6 +369,280 @@ async def test_logging_event_types():
         
         assert 'background_retrieval_attempt' in event_types
         assert 'background_retrieval_complete' in event_types
+
+
+@pytest.mark.asyncio
+async def test_schema_consistency():
+    """run_id should equal response_id and payload should have execution wrapper."""
+    df = pd.DataFrame({
+        'response_id': ['resp_schema_001'],
+        'custom_id': ['schema-test-001']
+    })
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logger = ParquetLogger(log_dir=tmpdir, buffer_size=1)
+
+        client = AsyncMock()
+        client.responses.retrieve = AsyncMock(
+            return_value=MagicMock(model_dump=lambda **kwargs: {'id': 'resp_schema_001', 'status': 'completed'})
+        )
+
+        await retrieve_background_responses(
+            df,
+            client,
+            logger=logger,
+            show_progress=False
+        )
+
+        log_df = pd.read_parquet(tmpdir)
+
+        # Verify standard SCHEMA columns are present
+        for col in ['timestamp', 'run_id', 'parent_run_id', 'custom_id', 'event_type', 'logger_metadata', 'payload']:
+            assert col in log_df.columns, f"Missing column: {col}"
+
+        # run_id must equal response_id (not empty string)
+        bg_rows = log_df[log_df['event_type'].isin(_BACKGROUND_EVENT_TYPES)]
+        assert all(bg_rows['run_id'] == 'resp_schema_001'), \
+            f"Expected run_id='resp_schema_001', got: {bg_rows['run_id'].unique()}"
+
+        # custom_id must be set
+        assert all(bg_rows['custom_id'] == 'schema-test-001')
+
+        # payload must have execution wrapper with run_id, custom_id, and data section
+        for _, row in bg_rows.iterrows():
+            payload = json.loads(row['payload'])
+            assert 'execution' in payload, "payload missing 'execution' section"
+            assert 'data' in payload, "payload missing 'data' section"
+            assert 'raw' in payload, "payload missing 'raw' section"
+            assert payload['execution']['run_id'] == 'resp_schema_001'
+            assert payload['execution']['custom_id'] == 'schema-test-001'
+            assert payload['execution']['parent_run_id'] == ''
+
+
+@pytest.mark.asyncio
+async def test_auto_discovery_from_storage():
+    """Auto-discovery should find pending responses and skip completed ones."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Write some background retrieval events to simulate prior state:
+        #   resp_pending  → latest event is background_retrieval_attempt (non-terminal)
+        #   resp_done     → latest event is background_retrieval_complete (terminal)
+        logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
+        from datetime import timezone
+
+        # Pending response: only an attempt event logged
+        logger._add_entry({
+            'timestamp': datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            'run_id': 'resp_pending',
+            'parent_run_id': '',
+            'custom_id': 'cid-pending',
+            'event_type': 'background_retrieval_attempt',
+            'logger_metadata': '{}',
+            'payload': json.dumps({
+                'event_type': 'background_retrieval_attempt',
+                'timestamp': '2026-01-01T00:00:00+00:00',
+                'execution': {'run_id': 'resp_pending', 'parent_run_id': '', 'custom_id': 'cid-pending', 'tags': [], 'metadata': {}},
+                'data': {'response_id': 'resp_pending', 'attempt_time': '2026-01-01T00:00:00+00:00'},
+                'raw': {}
+            })
+        })
+
+        # Completed response: attempt then complete events logged
+        logger._add_entry({
+            'timestamp': datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            'run_id': 'resp_done',
+            'parent_run_id': '',
+            'custom_id': 'cid-done',
+            'event_type': 'background_retrieval_attempt',
+            'logger_metadata': '{}',
+            'payload': json.dumps({
+                'event_type': 'background_retrieval_attempt',
+                'timestamp': '2026-01-01T00:00:00+00:00',
+                'execution': {'run_id': 'resp_done', 'parent_run_id': '', 'custom_id': 'cid-done', 'tags': [], 'metadata': {}},
+                'data': {'response_id': 'resp_done', 'attempt_time': '2026-01-01T00:00:00+00:00'},
+                'raw': {}
+            })
+        })
+        logger._add_entry({
+            'timestamp': datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc),
+            'run_id': 'resp_done',
+            'parent_run_id': '',
+            'custom_id': 'cid-done',
+            'event_type': 'background_retrieval_complete',
+            'logger_metadata': '{}',
+            'payload': json.dumps({
+                'event_type': 'background_retrieval_complete',
+                'timestamp': '2026-01-01T00:01:00+00:00',
+                'execution': {'run_id': 'resp_done', 'parent_run_id': '', 'custom_id': 'cid-done', 'tags': [], 'metadata': {}},
+                'data': {'response_id': 'resp_done', 'status': 'completed', 'poll_attempts': 1},
+                'raw': {}
+            })
+        })
+        logger.flush()
+
+        # Mock client returns completed for the pending response
+        client = AsyncMock()
+        client.responses.retrieve = AsyncMock(
+            return_value=MagicMock(
+                model_dump=lambda **kwargs: {'id': 'resp_pending', 'status': 'completed'}
+            )
+        )
+
+        # Use path_template="" so the resolved path is exactly tmpdir
+        # (mirroring how batch_process + retrieve would share the same resolved path)
+        storage_config = StorageConfig(output_dir=tmpdir, path_template="")
+        results = await retrieve_background_responses(
+            storage_config=storage_config,
+            openai_client=client,
+            show_progress=False,
+        )
+
+        # Only the pending response should have been retrieved
+        assert client.responses.retrieve.call_count == 1
+        call_args = client.responses.retrieve.call_args[0]
+        assert call_args[0] == 'resp_pending'
+
+        assert results is not None
+        assert len(results) == 1
+        assert results.iloc[0]['response_id'] == 'resp_pending'
+        assert results.iloc[0]['status'] == 'completed'
+
+
+@pytest.mark.asyncio
+async def test_auto_discovery_no_pending():
+    """When all responses are terminal, auto-discovery returns empty without API calls."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
+        from datetime import timezone
+
+        # Write a completed response
+        logger._add_entry({
+            'timestamp': datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc),
+            'run_id': 'resp_already_done',
+            'parent_run_id': '',
+            'custom_id': 'cid-done',
+            'event_type': 'background_retrieval_complete',
+            'logger_metadata': '{}',
+            'payload': json.dumps({
+                'event_type': 'background_retrieval_complete',
+                'timestamp': '2026-01-01T00:01:00+00:00',
+                'execution': {'run_id': 'resp_already_done', 'parent_run_id': '', 'custom_id': 'cid-done', 'tags': [], 'metadata': {}},
+                'data': {'response_id': 'resp_already_done', 'status': 'completed', 'poll_attempts': 1},
+                'raw': {}
+            })
+        })
+        logger.flush()
+
+        client = AsyncMock()
+        client.responses.retrieve = AsyncMock()
+
+        storage_config = StorageConfig(output_dir=tmpdir, path_template="")
+        results = await retrieve_background_responses(
+            storage_config=storage_config,
+            openai_client=client,
+            show_progress=False,
+        )
+
+        # No API calls should be made
+        assert client.responses.retrieve.call_count == 0
+        assert results is not None
+        assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_discovery_empty_storage():
+    """When storage is empty, auto-discovery returns empty without API calls."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        client = AsyncMock()
+        client.responses.retrieve = AsyncMock()
+
+        storage_config = StorageConfig(output_dir=tmpdir, path_template="")
+        results = await retrieve_background_responses(
+            storage_config=storage_config,
+            openai_client=client,
+            show_progress=False,
+        )
+
+        assert client.responses.retrieve.call_count == 0
+        assert results is not None
+        assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_discovery_requires_storage_config():
+    """Calling with neither df nor storage_config should raise ValueError."""
+    client = AsyncMock()
+
+    with pytest.raises(ValueError, match="storage_config"):
+        await retrieve_background_responses(
+            openai_client=client,
+            show_progress=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_source_local_uses_only_local_storage():
+    """source='local' should read only from LocalStorage, not S3."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from langchain_callback_parquet_logger.config import RetrievalConfig, S3Config
+
+        logger = ParquetLogger(log_dir=tmpdir, buffer_size=10)
+        from datetime import timezone
+
+        logger._add_entry({
+            'timestamp': datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            'run_id': 'resp_local_only',
+            'parent_run_id': '',
+            'custom_id': 'cid-local',
+            'event_type': 'background_retrieval_attempt',
+            'logger_metadata': '{}',
+            'payload': json.dumps({
+                'event_type': 'background_retrieval_attempt',
+                'timestamp': '2026-01-01T00:00:00+00:00',
+                'execution': {'run_id': 'resp_local_only', 'parent_run_id': '', 'custom_id': 'cid-local', 'tags': [], 'metadata': {}},
+                'data': {'response_id': 'resp_local_only', 'attempt_time': '2026-01-01T00:00:00+00:00'},
+                'raw': {}
+            })
+        })
+        logger.flush()
+
+        client = AsyncMock()
+        client.responses.retrieve = AsyncMock(
+            return_value=MagicMock(
+                model_dump=lambda **kwargs: {'id': 'resp_local_only', 'status': 'completed'}
+            )
+        )
+
+        # source="local" (default) — should find the entry written locally
+        rc = RetrievalConfig(source="local")
+        storage_config = StorageConfig(output_dir=tmpdir, path_template="")
+        results = await retrieve_background_responses(
+            storage_config=storage_config,
+            retrieval_config=rc,
+            openai_client=client,
+            show_progress=False,
+        )
+
+        assert client.responses.retrieve.call_count == 1
+        assert results.iloc[0]['response_id'] == 'resp_local_only'
+        assert results.iloc[0]['status'] == 'completed'
+
+
+@pytest.mark.asyncio
+async def test_source_s3_requires_s3_config():
+    """source='s3' without an s3_config should raise ValueError."""
+    from langchain_callback_parquet_logger.config import RetrievalConfig
+
+    client = AsyncMock()
+    # StorageConfig with no s3_config
+    storage_config = StorageConfig(output_dir="/tmp/test", path_template="")
+
+    with pytest.raises(ValueError, match="s3_config"):
+        await retrieve_background_responses(
+            storage_config=storage_config,
+            retrieval_config=RetrievalConfig(source="s3"),
+            openai_client=client,
+            show_progress=False,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,143 +1,159 @@
 """
-Tests for batch_run and batch_process helper functionality.
+Tests for Batch.run() and core batch processing functionality.
 """
 
+import asyncio
 import pytest
 import pandas as pd
-import os
-import tempfile
-from pathlib import Path
-from unittest.mock import patch, Mock, AsyncMock, MagicMock
-from langchain_callback_parquet_logger import batch_run, batch_process, with_tags
+from unittest.mock import Mock, AsyncMock
+from langchain_callback_parquet_logger import Batch, with_tags
+from langchain_callback_parquet_logger.config import (
+    LLMConfig, ProcessingConfig, StorageConfig, ColumnConfig
+)
 
 
-class TestBatchRun:
-    """Test batch_run functionality."""
-    
+def _make_mock_llm_class(ainvoke_side_effect=None, ainvoke_return=None):
+    """Create a MockLLM class with a shared AsyncMock for ainvoke.
+
+    Returns (MockLLM, ainvoke_mock) so tests can inspect call_count and call_args.
+    """
+    if ainvoke_side_effect is not None:
+        ainvoke_mock = AsyncMock(side_effect=ainvoke_side_effect)
+    else:
+        default_return = ainvoke_return or Mock(content="response")
+        ainvoke_mock = AsyncMock(return_value=default_return)
+
+    class MockLLM:
+        def __init__(self, **kwargs):
+            self.callbacks = kwargs.get('callbacks', [])
+            self.ainvoke = ainvoke_mock
+
+    MockLLM.__name__ = 'MockLLM'
+    MockLLM.__module__ = 'test_module'
+    return MockLLM, ainvoke_mock
+
+
+class TestBatch:
+    """Test Batch.run() functionality (core batch processing engine)."""
+
     @pytest.mark.asyncio
-    async def test_batch_run_basic(self, sample_dataframe, mock_llm):
+    async def test_batch_run_basic(self, sample_dataframe, tmp_path):
         """Test basic batch processing of DataFrame."""
-        # Prepare DataFrame
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
         df['config'] = df['id'].apply(lambda x: with_tags(custom_id=str(x)))
-        
-        # Run batch
-        results = await batch_run(
-            df, 
-            mock_llm, 
-            show_progress=False
+
+        MockLLM, ainvoke_mock = _make_mock_llm_class()
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
         )
-        
-        # Verify results
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert len(results) == len(df)
-        # Check that we got mock responses
         for r in results:
             assert hasattr(r, 'content') or isinstance(r, Mock)
-        assert mock_llm.ainvoke.call_count == len(df)
-    
+        assert ainvoke_mock.call_count == len(df)
+
     @pytest.mark.asyncio
-    async def test_batch_run_returns_results(self, sample_dataframe, mock_llm):
-        """Test that batch_run returns list by default."""
+    async def test_batch_run_returns_results(self, sample_dataframe, tmp_path):
+        """Test that Batch.run() returns list when return_results=True."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
-        
-        results = await batch_run(
-            df, 
-            mock_llm,
-            show_progress=False,
-            return_results=True  # Explicit default
+
+        MockLLM, _ = _make_mock_llm_class()
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
         )
-        
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert isinstance(results, list)
         assert len(results) == len(df)
-    
+
     @pytest.mark.asyncio
-    async def test_memory_efficient_mode(self, sample_dataframe, mock_llm):
+    async def test_memory_efficient_mode(self, sample_dataframe, tmp_path):
         """Test return_results=False returns None."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
-        
-        results = await batch_run(
-            df,
-            mock_llm,
-            show_progress=False,
-            return_results=False  # Memory-efficient mode
+
+        MockLLM, ainvoke_mock = _make_mock_llm_class()
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(show_progress=False, return_results=False),
         )
-        
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert results is None
-        # But LLM was still called
-        assert mock_llm.ainvoke.call_count == len(df)
-    
+        assert ainvoke_mock.call_count == len(df)
+
     @pytest.mark.asyncio
-    async def test_empty_dataframe(self, mock_llm):
+    async def test_empty_dataframe(self, tmp_path):
         """Test handling of empty DataFrame."""
         df = pd.DataFrame(columns=['prompt', 'config'])
-        
-        results = await batch_run(
-            df,
-            mock_llm,
-            show_progress=False
+
+        MockLLM, ainvoke_mock = _make_mock_llm_class()
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
         )
-        
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert results == []
-        assert mock_llm.ainvoke.call_count == 0
-    
+        assert ainvoke_mock.call_count == 0
+
     @pytest.mark.asyncio
-    async def test_custom_columns(self, sample_dataframe, mock_llm):
-        """Test using custom column names."""
+    async def test_custom_columns(self, sample_dataframe, tmp_path):
+        """Test using custom column names via ColumnConfig."""
         df = sample_dataframe.copy()
         df['my_prompt'] = df['text']
         df['my_config'] = df['id'].apply(lambda x: {'custom': x})
         df['my_tools'] = [[{'type': 'test'}]] * len(df)
-        
-        results = await batch_run(
-            df,
-            mock_llm,
-            prompt_col='my_prompt',
-            config_col='my_config',
-            tools_col='my_tools',
-            show_progress=False
+
+        MockLLM, ainvoke_mock = _make_mock_llm_class()
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            column_config=ColumnConfig(prompt='my_prompt', config='my_config', tools='my_tools'),
         )
-        
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert len(results) == len(df)
-        
+
         # Check that correct columns were used
-        call_args = mock_llm.ainvoke.call_args_list[0]
-        # Check the keyword arguments
+        call_args = ainvoke_mock.call_args_list[0]
         assert call_args.kwargs['input'] == 'Hello world'  # First prompt
         assert call_args.kwargs['config'] == {'custom': 1}
         assert call_args.kwargs['tools'] == [{'type': 'test'}]
-    
+
     @pytest.mark.asyncio
-    async def test_progress_bar(self, sample_dataframe, mock_llm, capsys):
+    async def test_progress_bar(self, sample_dataframe, tmp_path, capsys):
         """Test that print-based progress output works."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
 
-        results = await batch_run(
-            df,
-            mock_llm,
-            show_progress=True
+        MockLLM, ainvoke_mock = _make_mock_llm_class()
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(show_progress=True, return_results=True),
         )
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
 
         assert len(results) == len(df)
-        assert mock_llm.ainvoke.call_count == len(df)
+        assert ainvoke_mock.call_count == len(df)
 
         captured = capsys.readouterr()
         assert "Processed" in captured.out
-    
+
     @pytest.mark.asyncio
-    async def test_exception_handling(self, sample_dataframe):
+    async def test_exception_handling(self, sample_dataframe, tmp_path):
         """Test return_exceptions=True handles errors gracefully."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
-        
-        # Create LLM that raises error on second call
-        llm = Mock()
+
         call_count = 0
-        
-        async def mock_invoke_with_error(**kwargs):  # Accept keyword args
+
+        async def mock_invoke_with_error(**kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 2:
@@ -145,99 +161,93 @@ class TestBatchRun:
             response = Mock()
             response.content = f"Response {call_count}"
             return response
-        
-        llm.ainvoke = AsyncMock(side_effect=mock_invoke_with_error)
-        
-        # Run with return_exceptions=True
-        results = await batch_run(
-            df,
-            llm,
-            show_progress=False,
-            return_exceptions=True
+
+        MockLLM, ainvoke_mock = _make_mock_llm_class(ainvoke_side_effect=mock_invoke_with_error)
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(
+                show_progress=False, return_results=True, return_exceptions=True
+            ),
         )
-        
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert len(results) == len(df)
         assert isinstance(results[1], ValueError)
         assert results[0].content == "Response 1"
         assert results[2].content == "Response 3"
-    
+
     @pytest.mark.asyncio
-    async def test_max_concurrency(self, mock_llm):
+    async def test_max_concurrency(self, tmp_path):
         """Test max_concurrency limits parallel requests."""
-        # Create larger DataFrame
         df = pd.DataFrame({
             'prompt': [f'Prompt {i}' for i in range(10)]
         })
-        
-        # Track concurrent calls
-        concurrent_calls = []
+
         max_concurrent = 0
         current_concurrent = 0
-        
-        async def track_concurrency(input_text, **kwargs):
+
+        async def track_concurrency(**kwargs):
             nonlocal current_concurrent, max_concurrent
             current_concurrent += 1
             max_concurrent = max(max_concurrent, current_concurrent)
-            # Simulate some work
-            import asyncio
             await asyncio.sleep(0.01)
             current_concurrent -= 1
             response = Mock()
             response.content = "Response"
             return response
-        
-        llm = Mock()
-        llm.ainvoke = AsyncMock(side_effect=track_concurrency)
-        
-        await batch_run(
-            df,
-            llm,
-            max_concurrency=3,
-            show_progress=False
+
+        MockLLM, _ = _make_mock_llm_class(ainvoke_side_effect=track_concurrency)
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(
+                show_progress=False, return_results=True, max_concurrency=3
+            ),
         )
-        
-        # Max concurrency should not exceed limit
+        await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert max_concurrent <= 3
-    
+
     @pytest.mark.asyncio
-    async def test_missing_columns(self, sample_dataframe, mock_llm):
+    async def test_missing_columns(self, sample_dataframe, tmp_path):
         """Test handling of missing optional columns."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
         # No config or tools columns
-        
-        results = await batch_run(
-            df,
-            mock_llm,
-            config_col='missing_config',
-            tools_col='missing_tools',
-            show_progress=False
+
+        MockLLM, ainvoke_mock = _make_mock_llm_class()
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            column_config=ColumnConfig(
+                prompt='prompt', config='missing_config', tools='missing_tools'
+            ),
         )
-        
-        # Should still work
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert len(results) == len(df)
-        
-        # Check that None was passed for missing columns
-        call_args = mock_llm.ainvoke.call_args_list[0]
-        assert 'config' not in call_args[1] or call_args[1].get('config') is None
-        assert 'tools' not in call_args[1] or call_args[1].get('tools') is None
-    
+
+        # Check that config and tools were not passed (columns don't exist)
+        call_args = ainvoke_mock.call_args_list[0]
+        assert 'config' not in call_args.kwargs or call_args.kwargs.get('config') is None
+        assert 'tools' not in call_args.kwargs or call_args.kwargs.get('tools') is None
+
     @pytest.mark.asyncio
-    async def test_tools_column_none(self, sample_dataframe, mock_llm):
-        """Test setting tools_col=None to skip tools."""
+    async def test_tools_column_none(self, sample_dataframe, tmp_path):
+        """Test setting tools=None in ColumnConfig to skip tools."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
-        df['tools'] = [[{'type': 'test'}]] * len(df)  # This should be ignored
-        
-        results = await batch_run(
-            df,
-            mock_llm,
-            tools_col=None,  # Explicitly skip tools
-            show_progress=False
+        df['tools'] = [[{'type': 'test'}]] * len(df)  # Should be ignored
+
+        MockLLM, ainvoke_mock = _make_mock_llm_class()
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=str(tmp_path)),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            column_config=ColumnConfig(tools=None),  # Explicitly skip tools
         )
-        
+        results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
         assert len(results) == len(df)
-        
+
         # Verify tools were not passed
-        call_args = mock_llm.ainvoke.call_args_list[0]
-        assert 'tools' not in call_args[1]
+        call_args = ainvoke_mock.call_args_list[0]
+        assert 'tools' not in call_args.kwargs

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -1591,3 +1591,83 @@ async def test_batch_retrieve_s3_path_uses_s3_storage():
 
     # _query_pending_responses was called with the S3Storage instance
     mock_query.assert_called_once_with(MockS3Storage.return_value)
+
+
+@pytest.mark.asyncio
+async def test_batch_retrieve_explicit_df():
+    """Batch.retrieve(df=...) passes the df directly to retrieve_background_responses."""
+    explicit_df = pd.DataFrame({
+        'response_id': ['resp_explicit_001', 'resp_explicit_002'],
+        'custom_id': ['cid_001', 'cid_002'],
+    })
+
+    captured = {}
+
+    with patch(
+        'langchain_callback_parquet_logger.background_retrieval.retrieve_background_responses',
+        new_callable=AsyncMock,
+    ) as mock_retrieve:
+        mock_retrieve.return_value = pd.DataFrame({
+            'response_id': ['resp_explicit_001', 'resp_explicit_002'],
+            'status': ['completed', 'completed'],
+            'openai_response': [{}, {}],
+            'error': [None, None],
+        })
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir, path_template=""),
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            results = await batch.retrieve(
+                df=explicit_df,
+                retrieval_config=RetrievalConfig(show_progress=False),
+            )
+
+    # retrieve_background_responses was called with the explicit df
+    mock_retrieve.assert_called_once()
+    passed_df = mock_retrieve.call_args.kwargs['df']
+    assert list(passed_df['response_id']) == ['resp_explicit_001', 'resp_explicit_002']
+
+    assert results is not None
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_batch_retrieve_explicit_df_takes_priority_over_memory():
+    """Explicit df takes priority over in-memory _background_response_ids."""
+    explicit_df = pd.DataFrame({
+        'response_id': ['resp_from_df'],
+        'custom_id': ['cid_df'],
+    })
+
+    with patch(
+        'langchain_callback_parquet_logger.background_retrieval.retrieve_background_responses',
+        new_callable=AsyncMock,
+        return_value=pd.DataFrame({
+            'response_id': ['resp_from_df'],
+            'status': ['completed'],
+            'openai_response': [{}],
+            'error': [None],
+        }),
+    ) as mock_retrieve:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir, path_template=""),
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            # Populate in-memory IDs with a different response
+            batch._background_response_ids = {
+                'resp_from_memory': {'custom_id': 'cid_mem', 'run_id': '', 'parent_run_id': '', 'tags': []}
+            }
+
+            await batch.retrieve(
+                df=explicit_df,
+                retrieval_config=RetrievalConfig(show_progress=False),
+            )
+
+    # The df passed to retrieve_background_responses should be the explicit one (not memory)
+    passed_df = mock_retrieve.call_args.kwargs['df']
+    assert list(passed_df['response_id']) == ['resp_from_df'], (
+        "Expected df IDs, got memory IDs"
+    )

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -744,3 +744,151 @@ class TestBatch:
                     LLMConfig(llm_class=MockLLM, llm_kwargs={}),
                     response_id_extractor=crashing_extractor,
                 )
+
+    @pytest.mark.asyncio
+    async def test_run_returns_results_by_default(self, sample_dataframe):
+        """Test that run() returns a list by default (return_results now defaults to True).
+        Before this fix the default was False, causing silent None returns."""
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        MockLLM = create_mock_llm_class()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                # No return_results set — should default to True
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            result = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+
+            assert result is not None
+            assert isinstance(result, list)
+            assert len(result) == len(df)
+
+    @pytest.mark.asyncio
+    async def test_run_resets_ids_between_calls(self, sample_dataframe):
+        """Test that each run() call resets _background_response_ids so the second
+        call's IDs don't accumulate on top of the first call's IDs."""
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        call_count = 0
+
+        async def mock_ainvoke(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return Mock(
+                response_metadata={'id': f'resp_{call_count:03d}', 'status': 'in_progress'},
+                content='',
+            )
+
+        class MockChatOpenAI:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        MockChatOpenAI.__name__ = 'ChatOpenAI'
+        MockChatOpenAI.__module__ = 'test_module'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            # First run
+            await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+            first_ids = set(batch.pending_response_ids)
+
+            # Second run — IDs should be replaced entirely, not accumulated
+            await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+            second_ids = set(batch.pending_response_ids)
+
+            assert len(second_ids) == len(df)
+            assert first_ids.isdisjoint(second_ids), (
+                "Second run should have replaced first run's IDs, not accumulated them"
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_clears_ids_when_no_background_llm(self, sample_dataframe):
+        """Test that run() with a non-background LLM clears IDs from a prior run(),
+        preventing stale IDs from leaking into retrieve()."""
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        call_count = 0
+
+        async def mock_ainvoke_bg(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return Mock(
+                response_metadata={'id': f'resp_{call_count:03d}', 'status': 'in_progress'},
+                content='',
+            )
+
+        class MockChatOpenAI:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke_bg)
+
+        MockChatOpenAI.__name__ = 'ChatOpenAI'
+        MockChatOpenAI.__module__ = 'test_module'
+
+        MockLLM = create_mock_llm_class()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            # First run with background LLM — captures IDs
+            await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+            assert len(batch.pending_response_ids) == len(df)
+
+            # Second run with a plain LLM — IDs should be cleared, not preserved
+            await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
+            assert len(batch.pending_response_ids) == 0, (
+                "run() with a non-background LLM should clear IDs from the previous run"
+            )
+
+    @pytest.mark.asyncio
+    async def test_retrieve_logger_has_job_metadata(self):
+        """Test that retrieve() creates its ParquetLogger with job metadata so that
+        retrieval events have the same batch context as run() events."""
+        from langchain_callback_parquet_logger import JobConfig, RetrievalConfig, ParquetLogger
+        from unittest.mock import patch as _patch, AsyncMock as _AsyncMock
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                job_config=JobConfig(category='mycat', version='2.0'),
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            # Inject a fake response ID to trigger the retrieval path
+            batch._background_response_ids = {'resp_001': 'cid_001'}
+
+            captured_metadata = []
+
+            # Subclass to capture what logger_metadata is passed
+            original_init = ParquetLogger.__init__
+
+            def capturing_init(self, *args, **kwargs):
+                captured_metadata.append(kwargs.get('logger_metadata'))
+                original_init(self, *args, **kwargs)
+
+            with _patch.object(ParquetLogger, '__init__', capturing_init):
+                with _patch(
+                    'langchain_callback_parquet_logger.background_retrieval.retrieve_background_responses',
+                    new=_AsyncMock(return_value=pd.DataFrame()),
+                ):
+                    await batch.retrieve(
+                        retrieval_config=RetrievalConfig(show_progress=False, return_results=True)
+                    )
+
+            assert len(captured_metadata) == 1
+            meta = captured_metadata[0]
+            assert meta is not None, "retrieve() must pass logger_metadata to ParquetLogger"
+            assert 'batch_config' in meta
+            assert meta['batch_config']['job']['category'] == 'mycat'
+            assert meta['batch_config']['job']['version'] == '2.0'
+            assert 'retrieval_started_at' in meta

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -658,3 +658,89 @@ class TestBatch:
             # Verify no Parquet files were created (no storage access)
             parquet_files = list(Path(tmpdir).glob('**/*.parquet'))
             assert len(parquet_files) == 0
+
+    @pytest.mark.asyncio
+    async def test_run_captures_ids_when_return_results_false(self, sample_dataframe):
+        """Test that background response IDs are captured even when return_results=False.
+        run() should hold results in memory internally for ID extraction, then discard
+        them before returning to the caller."""
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        call_count = 0
+
+        async def mock_ainvoke(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return Mock(
+                response_metadata={'id': f'resp_{call_count:03d}', 'status': 'in_progress'},
+                content='',
+            )
+
+        class MockChatOpenAI:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        MockChatOpenAI.__name__ = 'ChatOpenAI'
+        MockChatOpenAI.__module__ = 'test_module'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                # return_results=False (the default) — would silently break ID capture before fix
+                processing_config=ProcessingConfig(show_progress=False, return_results=False),
+            )
+            result = await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+
+            # Caller gets None (respects return_results=False)
+            assert result is None
+            # But IDs were captured internally
+            assert len(batch.pending_response_ids) == len(df)
+            for rid in batch.pending_response_ids:
+                assert rid.startswith('resp_')
+
+    @pytest.mark.asyncio
+    async def test_retrieve_show_progress_false_suppresses_no_responses_print(self, capsys):
+        """Test that show_progress=False suppresses the 'No pending responses' message
+        when storage discovery finds nothing."""
+        from langchain_callback_parquet_logger import RetrievalConfig
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            # source='local' triggers storage discovery (which finds nothing)
+            await batch.retrieve(
+                retrieval_config=RetrievalConfig(source='local', return_results=True, show_progress=False)
+            )
+
+            captured = capsys.readouterr()
+            assert "No pending responses" not in captured.out
+
+    @pytest.mark.asyncio
+    async def test_extractor_exception_emits_warning(self, sample_dataframe):
+        """Test that a crashing response_id_extractor emits a warning rather than
+        silently swallowing the exception."""
+        import warnings as warnings_module
+
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        MockLLM = create_mock_llm_class()
+
+        def crashing_extractor(result, row):
+            raise ValueError("Extractor exploded!")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            with pytest.warns(UserWarning, match="Extractor exploded"):
+                await batch.run(
+                    df,
+                    LLMConfig(llm_class=MockLLM, llm_kwargs={}),
+                    response_id_extractor=crashing_extractor,
+                )

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -892,3 +892,216 @@ class TestBatch:
             assert meta['batch_config']['job']['category'] == 'mycat'
             assert meta['batch_config']['job']['version'] == '2.0'
             assert 'retrieval_started_at' in meta
+
+    @pytest.mark.asyncio
+    async def test_run_captures_ids_from_structured_output_valueerror(self):
+        """Test that response IDs are captured even when with_structured_output() raises
+        ValueError for queued background responses (the ID is in the exception message)."""
+        from langchain_callback_parquet_logger.batch import _try_extract_id_from_exception
+
+        # Verify the helper itself works on the expected ValueError format
+        fake_exc = ValueError(
+            "Structured Output response does not have a 'parsed' field nor a 'refusal' field. "
+            "Received message:\n\n"
+            "content=[] additional_kwargs={} response_metadata={'id': 'resp_abc123', "
+            "'status': 'queued', 'model': 'gpt-5'} id='resp_abc123'"
+        )
+        assert _try_extract_id_from_exception(fake_exc) == 'resp_abc123'
+
+        # Returns None for completed/failed statuses
+        completed_exc = ValueError(
+            "content=[] response_metadata={'id': 'resp_xyz', 'status': 'completed'} id='resp_xyz'"
+        )
+        assert _try_extract_id_from_exception(completed_exc) is None
+
+        # Returns None for unrelated exceptions
+        assert _try_extract_id_from_exception(RuntimeError("boom")) is None
+
+        # Now verify that run() captures IDs when all results are ValueErrors
+        df = pd.DataFrame({'prompt': ['a', 'b']})
+
+        class MockChatOpenAI:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+
+            def with_structured_output(self, schema):
+                call_count = 0
+
+                class StructuredWrapper:
+                    async def ainvoke(self_, input, config=None, **kwargs):
+                        nonlocal call_count
+                        call_count += 1
+                        rid = f'resp_bg{call_count:03d}'
+                        raise ValueError(
+                            f"Structured Output response does not have a 'parsed' field. "
+                            f"Received message:\n\ncontent=[] response_metadata={{'id': '{rid}', "
+                            f"'status': 'queued'}} id='{rid}'"
+                        )
+
+                return StructuredWrapper()
+
+        MockChatOpenAI.__name__ = 'ChatOpenAI'
+        MockChatOpenAI.__module__ = 'test_module'
+
+        from pydantic import BaseModel
+
+        class MySchema(BaseModel):
+            value: str
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(
+                    show_progress=False, return_results=True, return_exceptions=True
+                ),
+            )
+            import warnings as _w
+            with _w.catch_warnings():
+                _w.simplefilter("ignore", UserWarning)
+                await batch.run(
+                    df,
+                    LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}, structured_output=MySchema),
+                )
+
+        assert len(batch.pending_response_ids) == 2, (
+            "IDs should be extracted from ValueError exceptions thrown by with_structured_output()"
+        )
+        assert all(rid.startswith('resp_bg') for rid in batch.pending_response_ids)
+
+    @pytest.mark.asyncio
+    async def test_run_warns_when_structured_output_with_background_llm(self):
+        """Test that combining structured_output with a background-capable LLM emits a warning."""
+        import warnings as _w
+        from pydantic import BaseModel
+
+        class MySchema(BaseModel):
+            value: str
+
+        df = pd.DataFrame({'prompt': ['hello']})
+
+        class MockChatOpenAI:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+
+            def with_structured_output(self, schema):
+                class W:
+                    async def ainvoke(self_, input, config=None, **kwargs):
+                        raise ValueError(
+                            "Structured Output response does not have a 'parsed' field. "
+                            "Received message:\n\ncontent=[] response_metadata={'id': 'resp_warn1', "
+                            "'status': 'queued'} id='resp_warn1'"
+                        )
+                return W()
+
+        MockChatOpenAI.__name__ = 'ChatOpenAI'
+        MockChatOpenAI.__module__ = 'test_module'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(
+                    show_progress=False, return_results=True, return_exceptions=True
+                ),
+            )
+            with pytest.warns(UserWarning, match="structured_output"):
+                await batch.run(
+                    df,
+                    LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}, structured_output=MySchema),
+                )
+
+    @pytest.mark.asyncio
+    async def test_run_and_retrieve_prints_when_no_ids_captured(self, capsys):
+        """Test that run_and_retrieve() prints an explanatory message when no background
+        IDs are captured (e.g. synchronous LLM), instead of silently returning None."""
+        df = pd.DataFrame({'prompt': ['hello']})
+        MockLLM = create_mock_llm_class()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=True, return_results=True),
+            )
+            outcome = await batch.run_and_retrieve(
+                df, LLMConfig(llm_class=MockLLM, llm_kwargs={})
+            )
+
+        assert outcome.retrieval_results is None
+        captured = capsys.readouterr()
+        assert "No background response IDs captured" in captured.out
+        assert "retrieval skipped" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_retrieve_adds_parsed_output_column(self):
+        """Test that retrieve() adds a parsed_output column when _last_structured_output
+        is set, using _parse_from_openai_response() to validate the JSON text."""
+        from pydantic import BaseModel
+        from langchain_callback_parquet_logger.batch import _parse_from_openai_response
+        from langchain_callback_parquet_logger import RetrievalConfig
+
+        class Location(BaseModel):
+            city: str
+            country: str
+
+        # Verify the parser helper directly
+        response_dict = {
+            'output': [
+                {
+                    'content': [
+                        {'type': 'output_text', 'text': '{"city": "Paris", "country": "France"}'}
+                    ]
+                }
+            ]
+        }
+        result = _parse_from_openai_response(response_dict, Location)
+        assert isinstance(result, Location)
+        assert result.city == 'Paris'
+        assert result.country == 'France'
+
+        # Also verify via output_text convenience key
+        response_dict2 = {'output_text': '{"city": "Berlin", "country": "Germany"}'}
+        result2 = _parse_from_openai_response(response_dict2, Location)
+        assert isinstance(result2, Location)
+        assert result2.city == 'Berlin'
+
+        # Returns None for bad input
+        assert _parse_from_openai_response({}, Location) is None
+        assert _parse_from_openai_response({'output': []}, Location) is None
+
+        # End-to-end: retrieve() applies the schema when _last_structured_output is set
+        fake_retrieval_df = pd.DataFrame([
+            {
+                'response_id': 'resp_001',
+                'status': 'completed',
+                'openai_response': {
+                    'output': [
+                        {'content': [{'type': 'output_text', 'text': '{"city": "Tokyo", "country": "Japan"}'}]}
+                    ]
+                },
+                'error': None,
+            }
+        ])
+
+        from unittest.mock import patch as _patch, AsyncMock as _AsyncMock
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            batch._background_response_ids = {'resp_001': 'cid_001'}
+            batch._last_structured_output = Location
+
+            with _patch(
+                'langchain_callback_parquet_logger.background_retrieval.retrieve_background_responses',
+                new=_AsyncMock(return_value=fake_retrieval_df),
+            ):
+                results = await batch.retrieve(
+                    retrieval_config=RetrievalConfig(show_progress=False, return_results=True)
+                )
+
+        assert results is not None
+        assert 'parsed_output' in results.columns
+        parsed = results['parsed_output'].iloc[0]
+        assert isinstance(parsed, Location)
+        assert parsed.city == 'Tokyo'
+        assert parsed.country == 'Japan'

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -1077,6 +1077,9 @@ class TestBatch:
                         {'content': [{'type': 'output_text', 'text': '{"city": "Tokyo", "country": "Japan"}'}]}
                     ]
                 },
+                # retrieve_background_responses() now returns parsed_output as a dict;
+                # Batch.retrieve() converts it to a Pydantic instance.
+                'parsed_output': {'city': 'Tokyo', 'country': 'Japan'},
                 'error': None,
             }
         ])
@@ -1105,3 +1108,142 @@ class TestBatch:
         assert isinstance(parsed, Location)
         assert parsed.city == 'Tokyo'
         assert parsed.country == 'Japan'
+
+
+def test_parse_from_openai_response_handles_null_content():
+    """Test that _parse_from_openai_response does not raise TypeError when reasoning
+    output items have content=None (explicitly null in the JSON, not a missing key)."""
+    from pydantic import BaseModel
+    from langchain_callback_parquet_logger.batch import _parse_from_openai_response
+
+    class City(BaseModel):
+        name: str
+
+    # Reasoning item has content=None; message item has the actual output_text.
+    # item.get('content', []) returns None when the key exists with null value —
+    # (item.get('content') or []) returns [] instead, avoiding the TypeError.
+    response_dict = {
+        'output': [
+            {'type': 'reasoning', 'content': None},
+            {
+                'type': 'message',
+                'content': [{'type': 'output_text', 'text': '{"name": "Rome"}'}],
+            },
+        ]
+    }
+    result = _parse_from_openai_response(response_dict, City)
+    assert isinstance(result, City)
+    assert result.name == 'Rome'
+
+    # A response with only a reasoning item (no output_text) should return None gracefully.
+    response_only_reasoning = {'output': [{'type': 'reasoning', 'content': None}]}
+    assert _parse_from_openai_response(response_only_reasoning, City) is None
+
+
+def test_extract_custom_id_from_row_uses_config_tags():
+    """Test that extract_custom_id correctly extracts the ID from the tags list
+    produced by with_tags(custom_id='x') — the same format that Batch.run() now uses."""
+    from langchain_callback_parquet_logger.tagging import extract_custom_id
+    from langchain_callback_parquet_logger import with_tags
+
+    config = with_tags(custom_id='abc')
+    tags = config.get('tags', [])
+    assert extract_custom_id(tags) == 'abc'
+
+    # Multiple tags — extract_custom_id should pick the right one
+    config2 = with_tags(custom_id='xyz')
+    tags2 = config2.get('tags', []) + ['some_other:tag']
+    assert extract_custom_id(tags2) == 'xyz'
+
+    # No custom_id tag → empty string
+    assert extract_custom_id(['other:tag', 'unrelated']) == ''
+    assert extract_custom_id([]) == ''
+
+
+@pytest.mark.asyncio
+async def test_run_captures_custom_id_from_config_tags():
+    """Test that Batch.run() populates custom_id from the config column tags when
+    there is no top-level custom_id column — mirrors what logger.py does for llm_end."""
+    call_count = 0
+
+    async def mock_ainvoke(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        return Mock(
+            response_metadata={'id': f'resp_cid{call_count:03d}', 'status': 'in_progress'},
+            content='',
+        )
+
+    class MockChatOpenAI:
+        def __init__(self, **kwargs):
+            self.callbacks = kwargs.get('callbacks', [])
+            self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+    MockChatOpenAI.__name__ = 'ChatOpenAI'
+    MockChatOpenAI.__module__ = 'test_module'
+
+    df = pd.DataFrame({
+        'prompt': ['hello', 'world'],
+        'config': [
+            with_tags(custom_id='user-001'),
+            with_tags(custom_id='user-002'),
+        ],
+    })
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=tmpdir),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
+        )
+        await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+
+    # Both IDs should have been captured with the correct custom_id values
+    assert len(batch.pending_response_ids) == 2
+    custom_ids = set(batch.pending_response_ids.values())
+    assert custom_ids == {'user-001', 'user-002'}
+
+
+@pytest.mark.asyncio
+async def test_retrieve_background_responses_includes_parsed_output():
+    """Test that retrieve_background_responses() calls response_parser for completed
+    responses and includes parsed_output in the returned DataFrame."""
+    from langchain_callback_parquet_logger.background_retrieval import retrieve_background_responses
+    from langchain_callback_parquet_logger import RetrievalConfig, ColumnConfig
+
+    # A fake completed response object
+    class FakeResponse:
+        status = 'completed'
+        output_text = '{"city": "Paris"}'
+
+        def model_dump(self, **kwargs):
+            return {'status': 'completed', 'output_text': self.output_text}
+
+    mock_client = AsyncMock()
+    mock_client.responses.retrieve = AsyncMock(return_value=FakeResponse())
+
+    df = pd.DataFrame({
+        'response_id': ['resp_test001'],
+        'custom_id': ['cid_001'],
+    })
+
+    # response_parser returns a dict (as Batch.retrieve() would build it)
+    def response_parser(response_dict: dict):
+        return {'city': 'Paris'}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        results = await retrieve_background_responses(
+            df=df,
+            openai_client=mock_client,
+            retrieval_config=RetrievalConfig(
+                show_progress=False,
+                return_results=True,
+                poll_interval=0,
+            ),
+            response_parser=response_parser,
+        )
+
+    assert results is not None
+    assert not results.empty
+    assert 'parsed_output' in results.columns
+    assert results['parsed_output'].iloc[0] == {'city': 'Paris'}
+    assert results['status'].iloc[0] == 'completed'

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -499,3 +499,108 @@ class TestBatch:
             assert outcome.batch_results is not None
             assert outcome.retrieval_results is not None
             batch.retrieve.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_retrieval_config_in_constructor(self, sample_dataframe):
+        """Test that RetrievalConfig stored in constructor is used as default in retrieve()."""
+        from langchain_callback_parquet_logger import RetrievalConfig
+
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        MockLLM = create_mock_llm_class()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rc = RetrievalConfig(poll_interval=99.0, max_poll_attempts=7, show_progress=False)
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+                retrieval_config=rc,
+            )
+
+            # Verify it's stored
+            assert batch.retrieval_config is rc
+            assert batch.retrieval_config.poll_interval == 99.0
+            assert batch.retrieval_config.max_poll_attempts == 7
+
+            # When retrieve() is called without explicit retrieval_config, it uses self.retrieval_config
+            captured_rc = {}
+            original_retrieve = batch.retrieve
+
+            async def spy_retrieve(openai_client=None, retrieval_config=None):
+                captured_rc['used'] = retrieval_config or batch.retrieval_config
+                return pd.DataFrame()
+
+            batch.retrieve = spy_retrieve
+            await batch.run_and_retrieve(
+                df,
+                llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={}),
+            )
+
+            assert captured_rc['used'].poll_interval == 99.0
+            assert captured_rc['used'].max_poll_attempts == 7
+
+    @pytest.mark.asyncio
+    async def test_openai_extractor_auto_applied(self, sample_dataframe):
+        """Test that response_id_extractor is auto-detected for ChatOpenAI-named classes
+        when response_metadata contains a pending status."""
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        call_count = 0
+
+        async def mock_ainvoke(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return Mock(
+                response_metadata={'id': f'resp_{call_count:03d}', 'status': 'in_progress'},
+                content='',
+            )
+
+        class MockChatOpenAI:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        MockChatOpenAI.__name__ = 'ChatOpenAI'
+        MockChatOpenAI.__module__ = 'test_module'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            # No response_id_extractor passed — should be auto-detected
+            await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+
+            assert len(batch.pending_response_ids) == len(df)
+            for rid in batch.pending_response_ids:
+                assert rid.startswith('resp_')
+
+    @pytest.mark.asyncio
+    async def test_openai_extractor_skips_synchronous(self, sample_dataframe):
+        """Test that auto-detected extractor returns None for synchronous completions
+        (status 'completed'), so they are not queued for background retrieval."""
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        class MockChatOpenAI:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(return_value=Mock(
+                    response_metadata={'id': 'chatcmpl_sync456', 'status': 'completed'},
+                    content='hello',
+                ))
+
+        MockChatOpenAI.__name__ = 'ChatOpenAI'
+        MockChatOpenAI.__module__ = 'test_module'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+
+            # Synchronous results should NOT be captured for retrieval
+            assert len(batch.pending_response_ids) == 0

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -11,7 +11,7 @@ from unittest.mock import patch, Mock, AsyncMock, MagicMock, PropertyMock
 from langchain_callback_parquet_logger import (
     Batch, BatchOutcome, with_tags,
     LLMConfig, JobConfig, StorageConfig, ProcessingConfig,
-    ColumnConfig, S3Config
+    ColumnConfig, S3Config, RetrievalConfig
 )
 
 
@@ -1496,3 +1496,98 @@ def test_query_pending_responses_reads_response_id_from_payload():
         "Should use response_id from payload, not the LangChain run_id"
     )
     assert result['custom_id'].iloc[0] == 'cid-test'
+
+
+@pytest.mark.asyncio
+async def test_batch_run_logs_queued_event():
+    """Batch.run() logs a background_retrieval_queued event for each background response."""
+    import json
+    from langchain_callback_parquet_logger.background_retrieval import _BACKGROUND_EVENT_TYPES
+
+    call_count = 0
+
+    async def mock_ainvoke(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        return Mock(
+            response_metadata={'id': f'resp_queued{call_count:03d}', 'status': 'in_progress'},
+            content='',
+        )
+
+    class MockChatOpenAI:
+        def __init__(self, **kwargs):
+            self.callbacks = kwargs.get('callbacks', [])
+            self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+    MockChatOpenAI.__name__ = 'ChatOpenAI'
+    MockChatOpenAI.__module__ = 'test_module'
+
+    df = pd.DataFrame({
+        'prompt': ['hello', 'world'],
+        'config': [with_tags(custom_id='q1'), with_tags(custom_id='q2')],
+    })
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=tmpdir, path_template=""),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
+        )
+        await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+        batch._logger_flush_for_test = True  # ensure parquet written (logger context exited)
+
+        log_df = pd.read_parquet(tmpdir)
+
+    # Check background_retrieval_queued events were written
+    queued_events = log_df[log_df['event_type'] == 'background_retrieval_queued']
+    assert len(queued_events) == 2, f"Expected 2 queued events, got {len(queued_events)}"
+
+    # Each queued event should have the correct response_id in payload.data
+    for _, row in queued_events.iterrows():
+        payload = json.loads(row['payload'])
+        resp_id = payload['data']['response_id']
+        assert resp_id.startswith('resp_queued'), f"Unexpected response_id: {resp_id}"
+        # response_id must be in _background_response_ids
+        assert resp_id in batch._background_response_ids
+
+
+@pytest.mark.asyncio
+async def test_batch_retrieve_s3_path_uses_s3_storage():
+    """Batch.retrieve(s3_path=...) reads pending responses from S3Storage."""
+    pending_df = pd.DataFrame({
+        'response_id': ['resp_s3_resume'],
+        'custom_id': ['cid_s3'],
+        'run_id': ['lc-uuid'],
+        'parent_run_id': [''],
+        'tags': [[]],
+    })
+
+    with patch(
+        'langchain_callback_parquet_logger.background_retrieval._query_pending_responses',
+        return_value=pending_df
+    ) as mock_query, patch(
+        'langchain_callback_parquet_logger.storage.S3Storage'
+    ) as MockS3Storage, patch(
+        'langchain_callback_parquet_logger.background_retrieval.retrieve_background_responses',
+        new_callable=AsyncMock,
+        return_value=pd.DataFrame({'response_id': ['resp_s3_resume'], 'status': ['completed'],
+                                   'openai_response': [{}], 'error': [None]}),
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir, path_template=""),
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            # No in-memory IDs captured (simulates cross-process resume)
+            results = await batch.retrieve(
+                s3_path="s3://my-bucket/my/prefix/",
+                retrieval_config=RetrievalConfig(show_progress=False),
+            )
+
+    # S3Storage was created with the right bucket and prefix
+    MockS3Storage.assert_called_once()
+    s3_cfg_arg = MockS3Storage.call_args[0][0]
+    assert s3_cfg_arg.bucket == 'my-bucket'
+    assert s3_cfg_arg.prefix == 'my/prefix/'
+
+    # _query_pending_responses was called with the S3Storage instance
+    mock_query.assert_called_once_with(MockS3Storage.return_value)

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -1,5 +1,5 @@
 """
-Tests for batch_process functionality.
+Tests for Batch class functionality.
 """
 
 import pytest
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch, Mock, AsyncMock, MagicMock, PropertyMock
 from langchain_callback_parquet_logger import (
-    batch_process, with_tags,
+    Batch, BatchOutcome, with_tags,
     LLMConfig, JobConfig, StorageConfig, ProcessingConfig,
     ColumnConfig, S3Config
 )
@@ -39,12 +39,12 @@ def create_mock_llm_class():
     return MockLLM
 
 
-class TestBatchProcess:
-    """Test batch_process functionality."""
+class TestBatch:
+    """Test Batch class functionality."""
 
     @pytest.mark.asyncio
-    async def test_batch_process_local_only(self, sample_dataframe):
-        """Test batch_process with local storage only."""
+    async def test_batch_local_only(self, sample_dataframe):
+        """Test Batch.run() with local storage only."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
         df['config'] = df['id'].apply(lambda x: with_tags(custom_id=str(x)))
@@ -52,23 +52,14 @@ class TestBatchProcess:
         MockLLM = create_mock_llm_class()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            results = await batch_process(
+            batch = Batch(
+                job_config=JobConfig(category="test_job", subcategory="test_sub"),
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            results = await batch.run(
                 df,
-                llm_config=LLMConfig(
-                    llm_class=MockLLM,
-                    llm_kwargs={'model': 'test-model'}
-                ),
-                job_config=JobConfig(
-                    category="test_job",
-                    subcategory="test_sub"
-                ),
-                storage_config=StorageConfig(
-                    output_dir=tmpdir
-                ),
-                processing_config=ProcessingConfig(
-                    show_progress=False,
-                    return_results=True
-                )
+                llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={'model': 'test-model'}),
             )
 
             # Check that results were returned
@@ -80,8 +71,8 @@ class TestBatchProcess:
             assert expected_path.exists()
 
     @pytest.mark.asyncio
-    async def test_batch_process_with_s3(self, sample_dataframe):
-        """Test batch_process with S3 configuration."""
+    async def test_batch_with_s3(self, sample_dataframe):
+        """Test Batch.run() with S3 configuration."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
         df['config'] = df['id'].apply(lambda x: with_tags(custom_id=str(x)))
@@ -95,15 +86,8 @@ class TestBatchProcess:
                 mock_s3_client = MagicMock()
                 mock_client.return_value = mock_s3_client
 
-                results = await batch_process(
-                    df,
-                    llm_config=LLMConfig(
-                        llm_class=MockLLM,
-                        llm_kwargs={'model': 'test-model'}
-                    ),
-                    job_config=JobConfig(
-                        category="test_job"
-                    ),
+                batch = Batch(
+                    job_config=JobConfig(category="test_job"),
                     storage_config=StorageConfig(
                         output_dir=tmpdir,
                         path_template="{job_category}/{job_subcategory}",
@@ -115,7 +99,11 @@ class TestBatchProcess:
                     processing_config=ProcessingConfig(
                         show_progress=False,
                         buffer_size=1  # Force immediate flush to test S3 upload
-                    )
+                    ),
+                )
+                results = await batch.run(
+                    df,
+                    llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={'model': 'test-model'}),
                 )
 
                 # Check local directory was created
@@ -123,8 +111,8 @@ class TestBatchProcess:
                 assert expected_path.exists()
 
     @pytest.mark.asyncio
-    async def test_batch_process_structured_output(self, sample_dataframe):
-        """Test batch_process with structured output."""
+    async def test_batch_structured_output(self, sample_dataframe):
+        """Test Batch.run() with structured output."""
         from pydantic import BaseModel
 
         class TestModel(BaseModel):
@@ -150,27 +138,24 @@ class TestBatchProcess:
         MockStructuredLLM.__module__ = 'test_module'
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            results = await batch_process(
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            results = await batch.run(
                 df,
                 llm_config=LLMConfig(
                     llm_class=MockStructuredLLM,
                     llm_kwargs={'model': 'test-model'},
                     structured_output=TestModel
                 ),
-                storage_config=StorageConfig(
-                    output_dir=tmpdir
-                ),
-                processing_config=ProcessingConfig(
-                    show_progress=False,
-                    return_results=True
-                )
             )
 
             # Check results
             assert len(results) == len(df)
 
     @pytest.mark.asyncio
-    async def test_batch_process_llm_types(self, sample_dataframe):
+    async def test_batch_llm_types(self, sample_dataframe):
         """Test that different LLM classes work with batch processing."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
@@ -198,26 +183,20 @@ class TestBatchProcess:
                     mock_logger_instance.__enter__ = Mock(return_value=mock_logger_instance)
                     mock_logger_instance.__exit__ = Mock(return_value=None)
 
-                    await batch_process(
+                    batch = Batch(
+                        storage_config=StorageConfig(output_dir=tmpdir),
+                        processing_config=ProcessingConfig(show_progress=False, buffer_size=1000),
+                    )
+                    await batch.run(
                         df,
-                        llm_config=LLMConfig(
-                            llm_class=MockTypedLLM,
-                            llm_kwargs={'model': 'test-model'}
-                        ),
-                        storage_config=StorageConfig(
-                            output_dir=tmpdir
-                        ),
-                        processing_config=ProcessingConfig(
-                            show_progress=False,
-                            buffer_size=1000
-                        )
+                        llm_config=LLMConfig(llm_class=MockTypedLLM, llm_kwargs={'model': 'test-model'}),
                     )
 
                     # Check that ParquetLogger was called
                     assert MockLogger.called
 
     @pytest.mark.asyncio
-    async def test_batch_process_path_templates(self, sample_dataframe):
+    async def test_batch_path_templates(self, sample_dataframe):
         """Test path template formatting."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
@@ -226,12 +205,7 @@ class TestBatchProcess:
         MockLLM = create_mock_llm_class()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            await batch_process(
-                df,
-                llm_config=LLMConfig(
-                    llm_class=MockLLM,
-                    llm_kwargs={'model': 'test-model'}
-                ),
+            batch = Batch(
                 job_config=JobConfig(
                     category="emails",
                     subcategory="validation",
@@ -242,9 +216,11 @@ class TestBatchProcess:
                     output_dir=tmpdir,
                     path_template="{environment}/{job_category}/v{job_version_safe}/{job_subcategory}"
                 ),
-                processing_config=ProcessingConfig(
-                    show_progress=False
-                )
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            await batch.run(
+                df,
+                llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={'model': 'test-model'}),
             )
 
             # Check that path was formatted correctly (version dots replaced with underscores)
@@ -252,7 +228,7 @@ class TestBatchProcess:
             assert expected_path.exists()
 
     @pytest.mark.asyncio
-    async def test_batch_process_override_params(self, sample_dataframe):
+    async def test_batch_override_params(self, sample_dataframe):
         """Test logger and batch override parameters."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
@@ -267,26 +243,24 @@ class TestBatchProcess:
                 mock_logger_instance.__enter__ = Mock(return_value=mock_logger_instance)
                 mock_logger_instance.__exit__ = Mock(return_value=None)
 
-                # Use valid ParquetLogger parameters in override
-                await batch_process(
+                batch = Batch(
+                    storage_config=StorageConfig(
+                        output_dir=tmpdir,
+                        s3_config=S3Config(bucket="test-bucket", retry_attempts=5)
+                    ),
+                    processing_config=ProcessingConfig(
+                        buffer_size=500,
+                        event_types=['llm_start', 'llm_end', 'chain_start'],
+                        show_progress=False
+                    ),
+                )
+                await batch.run(
                     df,
                     llm_config=LLMConfig(
                         llm_class=MockLLM,
                         llm_kwargs={'model': 'test-model'},
                         model_kwargs={'temperature': 0.5}
                     ),
-                    storage_config=StorageConfig(
-                        output_dir=tmpdir,
-                        s3_config=S3Config(
-                            bucket="test-bucket",
-                            retry_attempts=5
-                        )
-                    ),
-                    processing_config=ProcessingConfig(
-                        buffer_size=500,
-                        event_types=['llm_start', 'llm_end', 'chain_start'],
-                        show_progress=False
-                    )
                 )
 
                 # Check that logger overrides were applied
@@ -297,27 +271,23 @@ class TestBatchProcess:
                     assert call_kwargs['event_types'] == ['llm_start', 'llm_end', 'chain_start']
 
     @pytest.mark.asyncio
-    async def test_batch_process_missing_columns(self, sample_dataframe):
+    async def test_batch_missing_columns(self, sample_dataframe):
         """Test error when required columns are missing."""
         df = sample_dataframe.copy()
         # Don't add the required 'prompt' column
 
         MockLLM = create_mock_llm_class()
 
-        with pytest.raises(ValueError, match="DataFrame missing required column"):
-            await batch_process(
-                df,
-                llm_config=LLMConfig(
-                    llm_class=MockLLM,
-                    llm_kwargs={'model': 'test-model'}
-                ),
-                storage_config=StorageConfig(
-                    output_dir="./test"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(storage_config=StorageConfig(output_dir=tmpdir))
+            with pytest.raises(ValueError, match="DataFrame missing required column"):
+                await batch.run(
+                    df,
+                    llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={'model': 'test-model'}),
                 )
-            )
 
     @pytest.mark.asyncio
-    async def test_batch_process_environment_s3_bucket(self, sample_dataframe):
+    async def test_batch_environment_s3_bucket(self, sample_dataframe):
         """Test that S3 bucket is read from environment variable."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
@@ -333,21 +303,16 @@ class TestBatchProcess:
                     mock_logger_instance.__enter__ = Mock(return_value=mock_logger_instance)
                     mock_logger_instance.__exit__ = Mock(return_value=None)
 
-                    await batch_process(
-                        df,
-                        llm_config=LLMConfig(
-                            llm_class=MockLLM,
-                            llm_kwargs={'model': 'test-model'}
-                        ),
+                    batch = Batch(
                         storage_config=StorageConfig(
                             output_dir=tmpdir,
-                            s3_config=S3Config(
-                                bucket='env-bucket'
-                            )
+                            s3_config=S3Config(bucket='env-bucket')
                         ),
-                        processing_config=ProcessingConfig(
-                            show_progress=False
-                        )
+                        processing_config=ProcessingConfig(show_progress=False),
+                    )
+                    await batch.run(
+                        df,
+                        llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={'model': 'test-model'}),
                     )
 
                     # Check that S3 bucket from env was used
@@ -360,7 +325,7 @@ class TestBatchProcess:
                             assert call_kwargs['s3_config'].bucket == 'env-bucket'
 
     @pytest.mark.asyncio
-    async def test_batch_process_version_paths(self, sample_dataframe):
+    async def test_batch_version_paths(self, sample_dataframe):
         """Test that versions are correctly sanitized in both local and S3 paths."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
@@ -374,12 +339,7 @@ class TestBatchProcess:
                 mock_s3_client = MagicMock()
                 mock_client.return_value = mock_s3_client
 
-                await batch_process(
-                    df,
-                    llm_config=LLMConfig(
-                        llm_class=MockLLM,
-                        llm_kwargs={'model': 'test-model'}
-                    ),
+                batch = Batch(
                     job_config=JobConfig(
                         category="ml_models",
                         subcategory="classification",
@@ -388,47 +348,32 @@ class TestBatchProcess:
                     storage_config=StorageConfig(
                         output_dir=tmpdir,
                         # Using default template which includes version
-                        s3_config=S3Config(
-                            bucket="test-bucket",
-                            prefix="models/"
-                        )
+                        s3_config=S3Config(bucket="test-bucket", prefix="models/")
                     ),
                     processing_config=ProcessingConfig(
                         show_progress=False,
                         buffer_size=1  # Force immediate flush
-                    )
+                    ),
+                )
+                await batch.run(
+                    df,
+                    llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={'model': 'test-model'}),
                 )
 
                 # Check local path has sanitized version
                 expected_local = Path(tmpdir) / "ml_models" / "classification" / "v3_2_1"
                 assert expected_local.exists(), f"Expected path {expected_local} does not exist"
 
-                # Check S3 prefix was set correctly with sanitized version
-                # The s3_config.prefix should have been updated to include the formatted path
-                logger_call = [call for call in mock_s3_client.put_object.call_args_list
-                             if call[1].get('Key', '').startswith('models/ml_models/classification/v3_2_1/')]
-                # We expect at least one call with the correct path structure
-                # Note: actual S3 upload verification would require checking mock_s3_client.put_object calls
-
         # Test 2: Without version specified (should use 'unversioned')
         with tempfile.TemporaryDirectory() as tmpdir:
-            await batch_process(
+            batch = Batch(
+                job_config=JobConfig(category="experiments", subcategory="baseline"),
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            await batch.run(
                 df,
-                llm_config=LLMConfig(
-                    llm_class=MockLLM,
-                    llm_kwargs={'model': 'test-model'}
-                ),
-                job_config=JobConfig(
-                    category="experiments",
-                    subcategory="baseline"
-                    # No version specified
-                ),
-                storage_config=StorageConfig(
-                    output_dir=tmpdir
-                ),
-                processing_config=ProcessingConfig(
-                    show_progress=False
-                )
+                llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={'model': 'test-model'}),
             )
 
             # Check local path has 'unversioned' as default
@@ -457,24 +402,21 @@ class TestBatchProcess:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             # This should not raise "RunnableSequence has no field callbacks"
-            results = await batch_process(
+            batch = Batch(
+                job_config=JobConfig(
+                    category="structured_test",
+                    description="Testing structured output with callbacks"
+                ),
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            results = await batch.run(
                 df,
                 llm_config=LLMConfig(
                     llm_class=MockLLM,
                     llm_kwargs={'model': 'test-model'},
                     structured_output=TestSchema  # This causes LLM to be wrapped in RunnableSequence
                 ),
-                job_config=JobConfig(
-                    category="structured_test",
-                    description="Testing structured output with callbacks"
-                ),
-                storage_config=StorageConfig(
-                    output_dir=tmpdir
-                ),
-                processing_config=ProcessingConfig(
-                    show_progress=False,
-                    return_results=True
-                )
             )
 
             # Verify the process completed without errors
@@ -484,3 +426,76 @@ class TestBatchProcess:
             # Check that callbacks were properly passed through LLM constructor
             # The MockLLM should have received callbacks in its kwargs
             # This is verified implicitly by the test not raising an error
+
+    @pytest.mark.asyncio
+    async def test_batch_pending_response_ids(self, sample_dataframe):
+        """Test that response_id_extractor captures background response IDs."""
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+        df['config'] = df['id'].apply(lambda x: with_tags(custom_id=str(x)))
+
+        # Mock LLM that returns objects with a response_id attribute
+        class MockBgLLM:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self._call_count = 0
+                self.ainvoke = AsyncMock(side_effect=self._invoke)
+
+            async def _invoke(self, **kwargs):
+                self._call_count += 1
+                result = Mock()
+                result.response_id = f'resp_{self._call_count:03d}'
+                result.content = 'queued response'
+                return result
+
+        MockBgLLM.__name__ = 'MockBgLLM'
+        MockBgLLM.__module__ = 'test_module'
+
+        def extract_id(result, row):
+            return getattr(result, 'response_id', None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(
+                    show_progress=False,
+                    return_results=True,
+                    return_exceptions=True,
+                ),
+            )
+            results = await batch.run(
+                df,
+                llm_config=LLMConfig(llm_class=MockBgLLM),
+                response_id_extractor=extract_id,
+            )
+
+            # Should have captured response IDs
+            assert len(batch.pending_response_ids) == len(df)
+            for rid in batch.pending_response_ids:
+                assert rid.startswith('resp_')
+
+    @pytest.mark.asyncio
+    async def test_batch_run_and_retrieve_structure(self, sample_dataframe):
+        """Test run_and_retrieve() returns a BatchOutcome with both result attributes."""
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        MockLLM = create_mock_llm_class()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            # Patch retrieve() to avoid needing a real OpenAI client
+            batch.retrieve = AsyncMock(return_value=pd.DataFrame())
+
+            outcome = await batch.run_and_retrieve(
+                df,
+                llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={'model': 'test-model'}),
+            )
+
+            assert isinstance(outcome, BatchOutcome)
+            assert outcome.batch_results is not None
+            assert outcome.retrieval_results is not None
+            batch.retrieve.assert_awaited_once()

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -476,7 +476,9 @@ class TestBatch:
 
     @pytest.mark.asyncio
     async def test_batch_run_and_retrieve_structure(self, sample_dataframe):
-        """Test run_and_retrieve() returns a BatchOutcome with both result attributes."""
+        """Test run_and_retrieve() with a synchronous LLM: returns BatchOutcome with
+        batch_results populated and retrieval_results=None (no background IDs captured,
+        so retrieve() is skipped)."""
         df = sample_dataframe.copy()
         df['prompt'] = df['text']
 
@@ -487,7 +489,6 @@ class TestBatch:
                 storage_config=StorageConfig(output_dir=tmpdir),
                 processing_config=ProcessingConfig(show_progress=False, return_results=True),
             )
-            # Patch retrieve() to avoid needing a real OpenAI client
             batch.retrieve = AsyncMock(return_value=pd.DataFrame())
 
             outcome = await batch.run_and_retrieve(
@@ -497,18 +498,14 @@ class TestBatch:
 
             assert isinstance(outcome, BatchOutcome)
             assert outcome.batch_results is not None
-            assert outcome.retrieval_results is not None
-            batch.retrieve.assert_awaited_once()
+            # Synchronous LLM — no background IDs captured, retrieve() must be skipped
+            assert outcome.retrieval_results is None
+            batch.retrieve.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_retrieval_config_in_constructor(self, sample_dataframe):
-        """Test that RetrievalConfig stored in constructor is used as default in retrieve()."""
+        """Test that RetrievalConfig stored in constructor is accessible and used as default."""
         from langchain_callback_parquet_logger import RetrievalConfig
-
-        df = sample_dataframe.copy()
-        df['prompt'] = df['text']
-
-        MockLLM = create_mock_llm_class()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             rc = RetrievalConfig(poll_interval=99.0, max_poll_attempts=7, show_progress=False)
@@ -523,22 +520,11 @@ class TestBatch:
             assert batch.retrieval_config.poll_interval == 99.0
             assert batch.retrieval_config.max_poll_attempts == 7
 
-            # When retrieve() is called without explicit retrieval_config, it uses self.retrieval_config
-            captured_rc = {}
-            original_retrieve = batch.retrieve
-
-            async def spy_retrieve(openai_client=None, retrieval_config=None):
-                captured_rc['used'] = retrieval_config or batch.retrieval_config
-                return pd.DataFrame()
-
-            batch.retrieve = spy_retrieve
-            await batch.run_and_retrieve(
-                df,
-                llm_config=LLMConfig(llm_class=MockLLM, llm_kwargs={}),
-            )
-
-            assert captured_rc['used'].poll_interval == 99.0
-            assert captured_rc['used'].max_poll_attempts == 7
+            # Calling retrieve() without args uses self.retrieval_config (source='memory' default)
+            # — returns empty DataFrame immediately without touching storage or needing a client
+            result = await batch.retrieve()
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) == 0
 
     @pytest.mark.asyncio
     async def test_openai_extractor_auto_applied(self, sample_dataframe):
@@ -604,3 +590,71 @@ class TestBatch:
 
             # Synchronous results should NOT be captured for retrieval
             assert len(batch.pending_response_ids) == 0
+
+    @pytest.mark.asyncio
+    async def test_run_and_retrieve_calls_retrieve_when_ids_captured(self, sample_dataframe):
+        """Test that run_and_retrieve() calls retrieve() when background IDs are captured."""
+        from langchain_callback_parquet_logger import RetrievalConfig
+
+        df = sample_dataframe.copy()
+        df['prompt'] = df['text']
+
+        call_count = 0
+
+        async def mock_ainvoke(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return Mock(
+                response_metadata={'id': f'resp_{call_count:03d}', 'status': 'in_progress'},
+                content='',
+            )
+
+        class MockChatOpenAI:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        MockChatOpenAI.__name__ = 'ChatOpenAI'
+        MockChatOpenAI.__module__ = 'test_module'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False, return_results=True),
+            )
+            # Patch retrieve() so we don't need a real OpenAI client
+            batch.retrieve = AsyncMock(return_value=pd.DataFrame({'response_id': ['resp_001']}))
+
+            outcome = await batch.run_and_retrieve(
+                df,
+                llm_config=LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}),
+            )
+
+            # Background IDs were captured — retrieve() should have been called
+            assert isinstance(outcome, BatchOutcome)
+            assert outcome.batch_results is not None
+            assert outcome.retrieval_results is not None
+            batch.retrieve.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_retrieve_source_memory_returns_empty(self):
+        """Test that retrieve() with source='memory' returns empty DataFrame
+        immediately without touching storage when no in-memory IDs are available."""
+        from langchain_callback_parquet_logger import RetrievalConfig
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(show_progress=False),
+            )
+            # No run() called — _background_response_ids is empty
+            # source='memory' (default) should return empty without reading any files
+            result = await batch.retrieve(
+                retrieval_config=RetrievalConfig(source='memory', return_results=True)
+            )
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) == 0
+
+            # Verify no Parquet files were created (no storage access)
+            parquet_files = list(Path(tmpdir).glob('**/*.parquet'))
+            assert len(parquet_files) == 0

--- a/tests/test_batch_process.py
+++ b/tests/test_batch_process.py
@@ -865,7 +865,7 @@ class TestBatch:
                 processing_config=ProcessingConfig(show_progress=False),
             )
             # Inject a fake response ID to trigger the retrieval path
-            batch._background_response_ids = {'resp_001': 'cid_001'}
+            batch._background_response_ids = {'resp_001': {'custom_id': 'cid_001', 'run_id': '', 'parent_run_id': '', 'tags': []}}
 
             captured_metadata = []
 
@@ -1091,7 +1091,7 @@ class TestBatch:
                 storage_config=StorageConfig(output_dir=tmpdir),
                 processing_config=ProcessingConfig(show_progress=False),
             )
-            batch._background_response_ids = {'resp_001': 'cid_001'}
+            batch._background_response_ids = {'resp_001': {'custom_id': 'cid_001', 'run_id': '', 'parent_run_id': '', 'tags': []}}
             batch._last_structured_output = Location
 
             with _patch(
@@ -1199,7 +1199,7 @@ async def test_run_captures_custom_id_from_config_tags():
 
     # Both IDs should have been captured with the correct custom_id values
     assert len(batch.pending_response_ids) == 2
-    custom_ids = set(batch.pending_response_ids.values())
+    custom_ids = {e['custom_id'] for e in batch.pending_response_ids.values()}
     assert custom_ids == {'user-001', 'user-002'}
 
 
@@ -1247,3 +1247,252 @@ async def test_retrieve_background_responses_includes_parsed_output():
     assert 'parsed_output' in results.columns
     assert results['parsed_output'].iloc[0] == {'city': 'Paris'}
     assert results['status'].iloc[0] == 'completed'
+
+
+# ---------------------------------------------------------------------------
+# New tests: run_id/parent_run_id/tags/raw flow through background retrieval
+# ---------------------------------------------------------------------------
+
+def test_background_run_id_capture_on_llm_end():
+    """Test that _BackgroundRunIdCapture.on_llm_end captures run_id and parent_run_id
+    when the LLM response contains a background (queued/in_progress) status."""
+    from langchain_callback_parquet_logger.batch import _BackgroundRunIdCapture
+    from unittest.mock import MagicMock
+    import uuid
+
+    capture = _BackgroundRunIdCapture()
+
+    run_id = uuid.uuid4()
+    parent_run_id = uuid.uuid4()
+
+    # Build a fake LLMResult with a background-status ChatGeneration
+    gen = MagicMock()
+    gen.message.response_metadata = {'id': 'resp_run_test001', 'status': 'queued'}
+    response = MagicMock()
+    response.generations = [[gen]]
+
+    capture.on_llm_end(response, run_id=run_id, parent_run_id=parent_run_id)
+
+    assert 'resp_run_test001' in capture.response_to_run
+    info = capture.response_to_run['resp_run_test001']
+    assert info['run_id'] == str(run_id)
+    assert info['parent_run_id'] == str(parent_run_id)
+
+    # Synchronous (completed) responses must NOT be captured
+    gen2 = MagicMock()
+    gen2.message.response_metadata = {'id': 'chatcmpl_sync', 'status': 'completed'}
+    response2 = MagicMock()
+    response2.generations = [[gen2]]
+
+    capture.on_llm_end(response2, run_id=uuid.uuid4())
+    assert 'chatcmpl_sync' not in capture.response_to_run
+
+
+@pytest.mark.asyncio
+async def test_run_stores_run_id_and_tags_in_background_ids():
+    """Test that Batch.run() stores run_id, parent_run_id, and tags in the
+    _background_response_ids dict alongside custom_id."""
+    call_count = 0
+
+    async def mock_ainvoke(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        return Mock(
+            response_metadata={'id': f'resp_rtag{call_count:03d}', 'status': 'in_progress'},
+            content='',
+        )
+
+    class MockChatOpenAI:
+        def __init__(self, **kwargs):
+            self.callbacks = kwargs.get('callbacks', [])
+            self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+    MockChatOpenAI.__name__ = 'ChatOpenAI'
+    MockChatOpenAI.__module__ = 'test_module'
+
+    df = pd.DataFrame({
+        'prompt': ['hello'],
+        'config': [with_tags(custom_id='run-tag-user')],
+    })
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=tmpdir),
+            processing_config=ProcessingConfig(show_progress=False, return_results=True),
+        )
+        await batch.run(df, LLMConfig(llm_class=MockChatOpenAI, llm_kwargs={}))
+
+    assert len(batch._background_response_ids) == 1
+    entry = next(iter(batch._background_response_ids.values()))
+    assert entry['custom_id'] == 'run-tag-user'
+    # Tags should include the logger_custom_id tag from with_tags()
+    assert any('logger_custom_id' in t for t in entry['tags'])
+    # run_id is empty string here because MockChatOpenAI doesn't go through
+    # the real LangChain callback chain — just verify the key exists
+    assert 'run_id' in entry
+    assert 'parent_run_id' in entry
+
+
+def test_pending_response_ids_returns_full_dict():
+    """Test that pending_response_ids returns the full dict (response_id → entry dict)
+    rather than a simple string mapping."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        batch = Batch(
+            storage_config=StorageConfig(output_dir=tmpdir),
+            processing_config=ProcessingConfig(show_progress=False),
+        )
+        batch._background_response_ids = {
+            'resp_A': {'custom_id': 'cid-a', 'run_id': 'uuid-1', 'parent_run_id': '', 'tags': ['x']},
+            'resp_B': {'custom_id': 'cid-b', 'run_id': 'uuid-2', 'parent_run_id': '', 'tags': []},
+        }
+
+        ids = batch.pending_response_ids
+        assert set(ids.keys()) == {'resp_A', 'resp_B'}
+        assert ids['resp_A']['custom_id'] == 'cid-a'
+        assert ids['resp_A']['run_id'] == 'uuid-1'
+        assert ids['resp_A']['tags'] == ['x']
+        assert ids['resp_B']['custom_id'] == 'cid-b'
+
+
+@pytest.mark.asyncio
+async def test_retrieval_events_use_original_run_id():
+    """Test that retrieve_background_responses() uses the run_id column from the df
+    (the original LangChain UUID) as the execution.run_id in logged events."""
+    from langchain_callback_parquet_logger.background_retrieval import retrieve_background_responses
+    from langchain_callback_parquet_logger import RetrievalConfig
+
+    class FakeResponse:
+        status = 'completed'
+        output_text = None
+
+        def model_dump(self, **kwargs):
+            return {'status': 'completed'}
+
+    mock_client = AsyncMock()
+    mock_client.responses.retrieve = AsyncMock(return_value=FakeResponse())
+
+    df = pd.DataFrame({
+        'response_id': ['resp_run_link001'],
+        'custom_id': ['cid_run'],
+        'run_id': ['langchain-uuid-xyz'],
+        'parent_run_id': ['parent-uuid-abc'],
+        'tags': [['logger_custom_id:cid_run', 'env:test']],
+    })
+
+    logged_payloads = []
+
+    class CapturingLogger:
+        def _log_event(self, payload):
+            logged_payloads.append(payload)
+
+        def flush(self):
+            pass
+
+    await retrieve_background_responses(
+        df=df,
+        openai_client=mock_client,
+        logger=CapturingLogger(),
+        retrieval_config=RetrievalConfig(show_progress=False, return_results=True, poll_interval=0),
+    )
+
+    assert len(logged_payloads) >= 2  # attempt + complete
+    for p in logged_payloads:
+        assert p['execution']['run_id'] == 'langchain-uuid-xyz', (
+            f"Expected run_id='langchain-uuid-xyz', got {p['execution']['run_id']!r}"
+        )
+        assert p['execution']['parent_run_id'] == 'parent-uuid-abc'
+        assert 'logger_custom_id:cid_run' in p['execution']['tags']
+
+    # The complete event should have raw populated with response_data
+    complete_events = [p for p in logged_payloads if p['event_type'] == 'background_retrieval_complete']
+    assert len(complete_events) == 1
+    assert isinstance(complete_events[0]['raw'], dict)
+    assert complete_events[0]['raw']  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_retrieval_complete_has_raw_response_data():
+    """Test that background_retrieval_complete events have raw populated with
+    the full serialized OpenAI response, matching the llm_end raw convention."""
+    from langchain_callback_parquet_logger.background_retrieval import retrieve_background_responses
+    from langchain_callback_parquet_logger import RetrievalConfig
+
+    class FakeResponse:
+        status = 'completed'
+        output_text = 'hello'
+
+        def model_dump(self, **kwargs):
+            return {'status': 'completed', 'output': [], 'output_text': 'hello'}
+
+    mock_client = AsyncMock()
+    mock_client.responses.retrieve = AsyncMock(return_value=FakeResponse())
+
+    df = pd.DataFrame({
+        'response_id': ['resp_raw_test'],
+        'custom_id': ['raw_cid'],
+    })
+
+    logged_payloads = []
+
+    class CapturingLogger:
+        def _log_event(self, payload):
+            logged_payloads.append(payload)
+
+        def flush(self):
+            pass
+
+    await retrieve_background_responses(
+        df=df,
+        openai_client=mock_client,
+        logger=CapturingLogger(),
+        retrieval_config=RetrievalConfig(show_progress=False, return_results=True, poll_interval=0),
+    )
+
+    complete_events = [p for p in logged_payloads if p['event_type'] == 'background_retrieval_complete']
+    assert len(complete_events) == 1
+    raw = complete_events[0]['raw']
+    assert isinstance(raw, dict)
+    assert raw.get('status') == 'completed'
+    assert raw.get('output_text') == 'hello'
+
+
+def test_query_pending_responses_reads_response_id_from_payload():
+    """Test that _query_pending_responses() extracts response_id from payload.data
+    rather than the run_id column (which now holds the LangChain UUID)."""
+    import json
+    from langchain_callback_parquet_logger.background_retrieval import _query_pending_responses
+    from langchain_callback_parquet_logger.storage import LocalStorage
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Write a fake Parquet file with run_id = LangChain UUID and
+        # payload.data.response_id = OpenAI response_id
+        langchain_uuid = 'lc-uuid-abc123'
+        openai_resp_id = 'resp_openai_xyz'
+
+        payload = json.dumps({
+            'event_type': 'background_retrieval_attempt',
+            'data': {'response_id': openai_resp_id},
+            'execution': {'run_id': langchain_uuid, 'custom_id': 'cid-test'},
+        })
+
+        table = pa.table({
+            'timestamp': pa.array([1], type=pa.int64()),
+            'run_id': [langchain_uuid],
+            'parent_run_id': [''],
+            'custom_id': ['cid-test'],
+            'event_type': ['background_retrieval_attempt'],
+            'logger_metadata': ['{}'],
+            'payload': [payload],
+        })
+        pq.write_table(table, f'{tmpdir}/test.parquet')
+
+        storage = LocalStorage(tmpdir)
+        result = _query_pending_responses(storage)
+
+    assert not result.empty
+    assert result['response_id'].iloc[0] == openai_resp_id, (
+        "Should use response_id from payload, not the LangChain run_id"
+    )
+    assert result['custom_id'].iloc[0] == 'cid-test'

--- a/tests/test_timeout_and_writer.py
+++ b/tests/test_timeout_and_writer.py
@@ -374,3 +374,50 @@ class TestBackgroundWriter:
 
         files = list(Path(temp_log_dir).glob("**/*.parquet"))
         assert len(files) == 1
+
+    def test_non_runtime_error_surfaces_at_flush(self, temp_log_dir):
+        """Test that non-RuntimeError write failures (e.g. OSError) surface at flush()
+        rather than being silently swallowed.  Before the fix, only RuntimeError was
+        re-raised; other exceptions were printed to stdout and discarded."""
+        logger = ParquetLogger(temp_log_dir, buffer_size=100)
+
+        logger._add_entry({
+            'timestamp': pd.Timestamp.now('UTC'),
+            'run_id': 'run-1',
+            'custom_id': '',
+            'event_type': 'test',
+            'parent_run_id': '',
+            'logger_metadata': '{}',
+            'payload': '{}'
+        })
+
+        # Sabotage with a non-RuntimeError to verify it also surfaces
+        def failing_write(*args, **kwargs):
+            raise OSError("Disk full")
+        logger.storage.write = failing_write
+
+        with pytest.raises(OSError, match="Disk full"):
+            logger.flush()
+
+
+class TestCompositeStorage:
+    """Test CompositeStorage behaviour."""
+
+    def test_list_files_warns_on_backend_failure(self, temp_log_dir):
+        """Test that CompositeStorage.list_files() emits a warning when a backend
+        fails rather than silently returning incomplete results."""
+        from langchain_callback_parquet_logger.storage import CompositeStorage, LocalStorage
+        from unittest.mock import MagicMock
+
+        good_backend = LocalStorage(Path(temp_log_dir))
+
+        bad_backend = MagicMock(spec=LocalStorage)
+        bad_backend.list_files.side_effect = Exception("S3 connection failed")
+
+        composite = CompositeStorage([good_backend, bad_backend])
+
+        with pytest.warns(UserWarning, match="S3 connection failed"):
+            files = composite.list_files()
+
+        # Good backend results are still returned despite the bad backend failing
+        assert isinstance(files, list)

--- a/tests/test_timeout_and_writer.py
+++ b/tests/test_timeout_and_writer.py
@@ -13,13 +13,13 @@ import pandas as pd
 import pytest
 
 from langchain_callback_parquet_logger import (
-    ParquetLogger, batch_run, batch_process, with_tags,
+    ParquetLogger, Batch, with_tags,
     ProcessingConfig, LLMConfig, StorageConfig, S3Config
 )
 
 
 class TestRowTimeout:
-    """Test per-row timeout in batch_run."""
+    """Test per-row timeout via Batch.run()."""
 
     @pytest.mark.asyncio
     async def test_timeout_returns_timeout_error(self):
@@ -36,15 +36,22 @@ class TestRowTimeout:
             response.content = f"Response to: {prompt}"
             return response
 
-        llm = Mock()
-        llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+        class MockLLM:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+        MockLLM.__name__ = 'MockLLM'
+        MockLLM.__module__ = 'test_module'
 
-        results = await batch_run(
-            df, llm,
-            show_progress=False,
-            return_exceptions=True,
-            row_timeout=0.1  # 100ms timeout
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(
+                    show_progress=False, return_results=True,
+                    return_exceptions=True, row_timeout=0.1,
+                ),
+            )
+            results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
 
         assert len(results) == 3
         # First and third should succeed
@@ -67,14 +74,21 @@ class TestRowTimeout:
             response.content = "ok"
             return response
 
-        llm = Mock()
-        llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+        class MockLLM:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+        MockLLM.__name__ = 'MockLLM'
+        MockLLM.__module__ = 'test_module'
 
-        results = await batch_run(
-            df, llm,
-            show_progress=False,
-            row_timeout=None  # No timeout
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(
+                    show_progress=False, return_results=True, row_timeout=None,
+                ),
+            )
+            results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
 
         assert len(results) == 2
         assert all(hasattr(r, 'content') for r in results)
@@ -89,20 +103,26 @@ class TestRowTimeout:
         async def mock_ainvoke(**kwargs):
             await asyncio.sleep(10)
 
-        llm = Mock()
-        llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+        class MockLLM:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+        MockLLM.__name__ = 'MockLLM'
+        MockLLM.__module__ = 'test_module'
 
-        with pytest.raises(TimeoutError, match="timed out"):
-            await batch_run(
-                df, llm,
-                show_progress=False,
-                return_exceptions=False,
-                row_timeout=0.1
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(
+                    show_progress=False, return_exceptions=False, row_timeout=0.1,
+                ),
             )
+            with pytest.raises(TimeoutError, match="timed out"):
+                await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
 
     @pytest.mark.asyncio
-    async def test_timeout_progress_bar_updates(self):
-        """Test that progress bar updates even on timeout."""
+    async def test_timeout_progress_counted_on_timeout(self):
+        """Test that progress counter increments even on timeout."""
         df = pd.DataFrame({
             'prompt': ['slow']
         })
@@ -110,15 +130,22 @@ class TestRowTimeout:
         async def mock_ainvoke(**kwargs):
             await asyncio.sleep(10)
 
-        llm = Mock()
-        llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+        class MockLLM:
+            def __init__(self, **kwargs):
+                self.callbacks = kwargs.get('callbacks', [])
+                self.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+        MockLLM.__name__ = 'MockLLM'
+        MockLLM.__module__ = 'test_module'
 
-        results = await batch_run(
-            df, llm,
-            show_progress=False,
-            return_exceptions=True,
-            row_timeout=0.1
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch = Batch(
+                storage_config=StorageConfig(output_dir=tmpdir),
+                processing_config=ProcessingConfig(
+                    show_progress=False, return_results=True,
+                    return_exceptions=True, row_timeout=0.1,
+                ),
+            )
+            results = await batch.run(df, LLMConfig(llm_class=MockLLM, llm_kwargs={}))
 
         assert len(results) == 1
         assert isinstance(results[0], TimeoutError)
@@ -150,19 +177,21 @@ class TestRowTimeout:
         df['config'] = df['id'].apply(lambda x: with_tags(custom_id=str(x)))
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            results = await batch_process(
-                df,
-                llm_config=LLMConfig(
-                    llm_class=MockLLM,
-                    llm_kwargs={'model': 'test-model'}
-                ),
+            batch = Batch(
                 storage_config=StorageConfig(output_dir=tmpdir),
                 processing_config=ProcessingConfig(
                     show_progress=False,
                     return_results=True,
                     return_exceptions=True,
                     row_timeout=0.1  # Short timeout
-                )
+                ),
+            )
+            results = await batch.run(
+                df,
+                llm_config=LLMConfig(
+                    llm_class=MockLLM,
+                    llm_kwargs={'model': 'test-model'}
+                ),
             )
 
             # At least one should be a TimeoutError (the "Hello world" row)


### PR DESCRIPTION
Summary
This branch builds out the background response retrieval system with better reliability, observability, and resume capability. Changes grouped by theme:

Bug fixes & reliability
- Fix background response ID capture when structured_output raises ValueError (the ID was being silently dropped)
- Fix custom_id extraction when it comes from with_tags() config rather than a top-level column
- Fix parsed_output to be populated during retrieval (not post-hoc), so it's always present in the Parquet log
- Seven additional correctness/reliability fixes across batch, logger, and storage (silent failures, UX issues, unexpected storage fallback)

Event schema improvements
- Background retrieval events now use the original LangChain run_id/parent_run_id (enabling WHERE run_id = X joins across llm_start, llm_end, and retrieval events)
- tags now flow from with_tags() config through to all retrieval event payloads
- raw field on background_retrieval_complete events now contains the full OpenAI response dict (no data loss)

Resume / recovery features
- New background_retrieval_queued event logged by Batch.run() at submission time — enables auto-discovery even if retrieve() is never called (previously auto-discovery required at least one retrieval attempt event)
- New s3_path parameter on Batch.retrieve() and retrieve_background_responses() — pass s3_path="s3://bucket/prefix/" to auto-discover pending responses and resume retrieval without reconstructing the full StorageConfig/JobConfig
- New df parameter on Batch.retrieve() — pass an explicit DataFrame of response IDs to force-retrieve specific responses, bypassing all auto-discovery


API improvements
- RetrievalConfig now accepted in Batch constructor
- Auto-detection of OpenAI background mode (no need to manually specify response_id_extractor)
- pending_response_ids now returns full metadata dict per response (run_id, custom_id, tags) instead of just a string mapping